### PR TITLE
:art: Pass mask to `bus::read`

### DIFF
--- a/include/groov/concepts.hpp
+++ b/include/groov/concepts.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <async/concepts.hpp>
+
+#include <stdx/ct_string.hpp>
+#include <stdx/type_traits.hpp>
+
+#include <concepts>
+#include <cstdint>
+
+namespace groov {
+namespace detail {
+template <stdx::ct_string Name> struct name_t;
+template <typename T> using name_of = typename T::name_t;
+} // namespace detail
+
+template <typename T>
+concept named =
+    stdx::is_specialization_of<typename T::name_t, detail::name_t>().value;
+
+template <typename T>
+concept containerlike = requires { typename T::children_t; };
+
+template <typename T>
+concept fieldlike = named<T> and containerlike<T> and
+                    std::unsigned_integral<decltype(T::mask)> and
+                    requires { typename T::type_t; };
+
+template <typename T>
+concept registerlike = fieldlike<T> and requires {
+    typename T::address_t;
+    { T::address } -> std::same_as<typename T::address_t const &>;
+};
+
+template <typename T, typename Reg>
+concept bus_for = requires {
+    { T::template read<typename Reg::type_t{}>(Reg::address) } -> async::sender;
+};
+} // namespace groov

--- a/test/fail/group_duplicate_path.cpp
+++ b/test/fail/group_duplicate_path.cpp
@@ -1,6 +1,3 @@
-#include <async/concepts.hpp>
-#include <async/just_result_of.hpp>
-
 #include <groov/object.hpp>
 #include <groov/path.hpp>
 
@@ -10,8 +7,12 @@
 
 namespace {
 struct bus {
-    static async::sender auto read(std::uint32_t *addr) {
-        return async::just_result_of([=] { return *addr; });
+    struct sender {
+        using is_sender = void;
+    };
+
+    template <auto> static auto read(auto) -> async::sender auto {
+        return sender{};
     }
 };
 

--- a/test/fail/group_redundant_path.cpp
+++ b/test/fail/group_redundant_path.cpp
@@ -1,6 +1,3 @@
-#include <async/concepts.hpp>
-#include <async/just_result_of.hpp>
-
 #include <groov/object.hpp>
 #include <groov/path.hpp>
 
@@ -10,8 +7,12 @@
 
 namespace {
 struct bus {
-    static async::sender auto read(std::uint32_t *addr) {
-        return async::just_result_of([=] { return *addr; });
+    struct sender {
+        using is_sender = void;
+    };
+
+    template <auto> static auto read(auto) -> async::sender auto {
+        return sender{};
     }
 };
 

--- a/test/fail/group_unresolvable_path.cpp
+++ b/test/fail/group_unresolvable_path.cpp
@@ -1,6 +1,3 @@
-#include <async/concepts.hpp>
-#include <async/just_result_of.hpp>
-
 #include <groov/object.hpp>
 #include <groov/path.hpp>
 
@@ -10,8 +7,12 @@
 
 namespace {
 struct bus {
-    static async::sender auto read(std::uint32_t *addr) {
-        return async::just_result_of([=] { return *addr; });
+    struct sender {
+        using is_sender = void;
+    };
+
+    template <auto> static auto read(auto) -> async::sender auto {
+        return sender{};
     }
 };
 

--- a/test/fail/read_ambiguous_path.cpp
+++ b/test/fail/read_ambiguous_path.cpp
@@ -1,5 +1,5 @@
 #include <async/concepts.hpp>
-#include <async/just_result_of.hpp>
+#include <async/just.hpp>
 #include <async/sync_wait.hpp>
 
 #include <groov/object.hpp>
@@ -12,8 +12,8 @@
 
 namespace {
 struct bus {
-    static async::sender auto read(std::uint32_t *addr) {
-        return async::just_result_of([=] { return *addr; });
+    template <auto> static auto read(auto) -> async::sender auto {
+        return async::just(42);
     }
 };
 

--- a/test/fail/read_invalid_path.cpp
+++ b/test/fail/read_invalid_path.cpp
@@ -1,5 +1,5 @@
 #include <async/concepts.hpp>
-#include <async/just_result_of.hpp>
+#include <async/just.hpp>
 #include <async/sync_wait.hpp>
 
 #include <groov/object.hpp>
@@ -12,8 +12,8 @@
 
 namespace {
 struct bus {
-    static async::sender auto read(std::uint32_t *addr) {
-        return async::just_result_of([=] { return *addr; });
+    template <auto> static auto read(auto) -> async::sender auto {
+        return async::just(42);
     }
 };
 

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -4,6 +4,18 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+namespace {
+struct bus {
+    struct sender {
+        using is_sender = void;
+    };
+
+    template <auto> static auto read(auto) -> async::sender auto {
+        return sender{};
+    }
+};
+} // namespace
+
 TEST_CASE("fields inside a register", "[object]") {
     using F = groov::field<"field", std::uint32_t, 0, 0>;
     using R = groov::reg<"reg", std::uint32_t, 0, F>;
@@ -13,7 +25,7 @@ TEST_CASE("fields inside a register", "[object]") {
 
 TEST_CASE("registers in a group", "[object]") {
     using R = groov::reg<"reg", std::uint32_t, 0>;
-    using G = groov::group<"group", void, R>;
+    using G = groov::group<"group", bus, R>;
     using X = groov::get_child<"reg", G>;
     static_assert(std::same_as<R, X>);
 }
@@ -100,25 +112,25 @@ TEST_CASE("ambiguous subpath gives ambiguous resolution", "[object]") {
 TEST_CASE("group with paths", "[object]") {
     using namespace groov::literals;
     using R = groov::reg<"reg", std::uint32_t, 0>;
-    using G = groov::group<"group", void, R>;
+    using G = groov::group<"group", bus, R>;
     constexpr auto grp = G{};
     constexpr auto x = grp("reg"_r);
     static_assert(
         std::is_same_v<decltype(x),
                        groov::group_with_paths<
-                           "group", void,
+                           "group", bus,
                            boost::mp11::mp_list<decltype("reg"_r)>, R> const>);
 }
 
 TEST_CASE("group with paths using operator/", "[object]") {
     using namespace groov::literals;
     using R = groov::reg<"reg", std::uint32_t, 0>;
-    using G = groov::group<"group", void, R>;
+    using G = groov::group<"group", bus, R>;
     constexpr auto grp = G{};
     constexpr auto x = grp / "reg"_r;
     static_assert(
         std::is_same_v<decltype(x),
                        groov::group_with_paths<
-                           "group", void,
+                           "group", bus,
                            boost::mp11::mp_list<decltype("reg"_r)>, R> const>);
 }


### PR DESCRIPTION
This will enable a bus to optionally use byte enables. Also, separate and beef up concepts a bit.