### PR TITLE
:art: Simplify path handling

### DIFF
--- a/include/groov/object.hpp
+++ b/include/groov/object.hpp
@@ -10,6 +10,7 @@
 #include <boost/mp11/list.hpp>
 
 #include <cstddef>
+#include <iterator>
 #include <limits>
 #include <type_traits>
 
@@ -45,19 +46,18 @@ constexpr auto resolve_matches([[maybe_unused]] P p) {
     }
 }
 
-template <typename T, pathlike P>
-constexpr auto recursive_resolve([[maybe_unused]] P p) {
-    constexpr auto root = P::root();
+template <typename T, pathlike P> constexpr auto recursive_resolve(P p) {
+    constexpr auto r = root(p);
     using children_t = typename T::children_t;
-    if constexpr (root == T::name) {
-        using leftover_path = decltype(P::without_root());
-        if constexpr (boost::mp11::mp_empty<leftover_path>::value) {
+    if constexpr (r == T::name) {
+        auto const leftover_path = without_root(p);
+        if constexpr (std::empty(leftover_path)) {
             return T{};
         } else {
             using matches =
                 boost::mp11::mp_copy_if_q<children_t,
-                                          resolves_q<leftover_path>>;
-            return resolve_matches<matches>(leftover_path{});
+                                          resolves_q<decltype(leftover_path)>>;
+            return resolve_matches<matches>(leftover_path);
         }
     } else {
         using matches = boost::mp11::mp_copy_if_q<children_t, resolves_q<P>>;

--- a/include/groov/read.hpp
+++ b/include/groov/read.hpp
@@ -25,19 +25,19 @@ auto read() -> async::sender auto {
 
 template <typename Group> struct register_for_path_q {
     template <pathlike P>
-    using fn = typename Group::template child_t<P::root()>;
+    using fn = typename Group::template child_t<root(P{})>;
 };
 
 template <typename Group> struct register_for_paths_q {
     template <typename L>
-    using fn =
-        typename Group::template child_t<boost::mp11::mp_front<L>::root()>;
+    using fn = typename register_for_path_q<Group>::template fn<
+        boost::mp11::mp_front<L>>;
 };
 
 template <typename Group> struct field_mask_for_paths_q {
     template <typename L>
-    using mask_t = typename Group::template child_t<
-        boost::mp11::mp_front<L>::root()>::type_t;
+    using mask_t = typename Group::template child_t<root(
+        boost::mp11::mp_front<L>{})>::type_t;
 
     template <typename L> constexpr static auto compute_mask() {
         mask_t<L> mask{};

--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -8,6 +8,7 @@ add_fail_tests(
     group_duplicate_path
     group_redundant_path
     group_unresolvable_path
+    path_ambiguous
     path_mismatch
     path_too_long
     read_ambiguous_path

--- a/test/fail/path_ambiguous.cpp
+++ b/test/fail/path_ambiguous.cpp
@@ -1,0 +1,9 @@
+#include <groov/path.hpp>
+
+// EXPECT: Attempting to access value with an ambiguous path
+
+auto main() -> int {
+    using namespace groov::literals;
+    constexpr auto v = "reg"_r("field"_f = 5, "field"_f = 10.0);
+    constexpr auto x = v["reg.field"_f];
+}

--- a/test/path.cpp
+++ b/test/path.cpp
@@ -4,45 +4,45 @@
 
 #include <type_traits>
 
-TEST_CASE("register literal", "[identifier]") {
+TEST_CASE("register literal", "[path]") {
     using namespace groov::literals;
     constexpr auto r = "reg"_r;
     static_assert(std::is_same_v<decltype(r), groov::path<"reg"> const>);
 }
 
-TEST_CASE("field literal", "[identifier]") {
+TEST_CASE("field literal", "[path]") {
     using namespace groov::literals;
     constexpr auto f = "field"_f;
     static_assert(std::is_same_v<decltype(f), groov::path<"field"> const>);
 }
 
-TEST_CASE("dot-separated literal", "[identifier]") {
+TEST_CASE("dot-separated literal", "[path]") {
     using namespace groov::literals;
-    constexpr auto f = "reg.field"_f;
+    constexpr auto f = "a.b.c.d"_f;
     static_assert(
-        std::is_same_v<decltype(f), groov::path<"reg", "field"> const>);
+        std::is_same_v<decltype(f), groov::path<"a", "b", "c", "d"> const>);
 }
 
-TEST_CASE("path concatenation with /", "[identifier]") {
+TEST_CASE("path concatenation with /", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "reg"_r / "field"_f;
     static_assert(p == "reg.field"_f);
 }
 
-TEST_CASE("path can resolve itself", "[resolve]") {
+TEST_CASE("path can resolve itself", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "a"_r;
     static_assert(groov::is_resolvable_v<decltype(p), decltype(p)>);
 }
 
-TEST_CASE("path resolves itself to empty path", "[resolve]") {
+TEST_CASE("path resolves itself to empty path", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "a"_r;
     constexpr auto r = groov::resolve(p, p);
     static_assert(std::is_same_v<decltype(r), groov::path<> const>);
 }
 
-TEST_CASE("path resolves a shorter path", "[resolve]") {
+TEST_CASE("path resolves a shorter path", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "a.b.c"_r;
     constexpr auto r1 = groov::resolve(p, "a"_r);
@@ -51,40 +51,40 @@ TEST_CASE("path resolves a shorter path", "[resolve]") {
     static_assert(r2 == "c"_r);
 }
 
-TEST_CASE("path doesn't resolve a non-path", "[resolve]") {
+TEST_CASE("path doesn't resolve a non-path", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "a.b.c"_r;
     static_assert(not groov::can_resolve<decltype(p), int>);
 }
 
-TEST_CASE("path doesn't resolve a different path", "[resolve]") {
+TEST_CASE("path doesn't resolve a different path", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "a.b.c"_r;
     constexpr auto x = "c"_r;
     static_assert(not groov::can_resolve<decltype(p), decltype(x)>);
 }
 
-TEST_CASE("path provides its own root", "[resolve]") {
+TEST_CASE("root of a path", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "a.b.c"_r;
-    static_assert(p.root() == stdx::ct_string{"a"});
+    static_assert(root(p) == stdx::ct_string{"a"});
 }
 
-TEST_CASE("path without its root", "[resolve]") {
+TEST_CASE("path without its root", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "a.b.c"_r;
-    static_assert(p.without_root() == "b.c"_r);
+    static_assert(without_root(p) == "b.c"_r);
 }
 
-TEST_CASE("path with value (operator=)", "[identifier]") {
+TEST_CASE("path with value (operator=)", "[path]") {
     using namespace groov::literals;
-    constexpr auto v = ("reg"_r / "field"_f = 5);
+    constexpr auto v = "reg"_r / "field"_f = 5;
     static_assert(std::is_same_v<groov::get_path_t<decltype(v)>,
                                  decltype("reg.field"_f)>);
     static_assert(v.value == 5);
 }
 
-TEST_CASE("path with value (operator())", "[identifier]") {
+TEST_CASE("path with value (operator())", "[path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r(5);
     static_assert(
@@ -92,74 +92,83 @@ TEST_CASE("path with value (operator())", "[identifier]") {
     static_assert(v.value == 5);
 }
 
-TEST_CASE("path with value can resolve path", "[identifier]") {
+TEST_CASE("path with value can resolve path", "[path]") {
     using namespace groov::literals;
-    constexpr auto v = ("reg"_r / "field"_f = 5);
+    constexpr auto v = "reg"_r / "field"_f = 5;
     constexpr auto r = groov::resolve(v, "reg"_r);
     static_assert(
         std::is_same_v<groov::get_path_t<decltype(r)>, decltype("field"_f)>);
     static_assert(r.value == 5);
 }
 
-TEST_CASE("mismatched path gives invalid resolution", "[identifier]") {
+TEST_CASE("mismatched path gives invalid resolution", "[path]") {
     using namespace groov::literals;
-    constexpr auto v = ("reg"_r / "field"_f = 5);
+    constexpr auto v = "reg"_r / "field"_f = 5;
     static_assert(std::is_same_v<groov::mismatch_t,
                                  decltype(groov::resolve(v, "invalid"_r))>);
 }
 
-TEST_CASE("too-long path gives invalid resolution", "[identifier]") {
+TEST_CASE("too-long path gives invalid resolution", "[path]") {
     using namespace groov::literals;
-    constexpr auto v = ("reg"_r / "field"_f = 5);
+    constexpr auto v = "reg"_r / "field"_f = 5;
     static_assert(
         std::is_same_v<groov::too_long_t,
                        decltype(groov::resolve(v, "reg.field.foo"_r))>);
 }
 
-TEST_CASE("register with multiple field values", "[identifier]") {
+TEST_CASE("ambiguous path gives invalid resolution", "[path]") {
+    using namespace groov::literals;
+    constexpr auto v = "reg"_r("field"_f = 5, "field"_f = 6);
+    static_assert(std::is_same_v<groov::ambiguous_t,
+                                 decltype(groov::resolve(v, "reg.field"_r))>);
+}
+
+TEST_CASE("register with multiple field values", "[path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r("field1"_f = 5, "field2"_f = 10.0);
     static_assert(
         std::is_same_v<
             decltype(v),
-            groov::with_values_t<
+            groov::with_value_t<
                 groov::path<"reg">,
-                groov::with_values_t<groov::path<"field1">, int>,
-                groov::with_values_t<groov::path<"field2">, double>> const>);
+                stdx::tuple<groov::with_value_t<groov::path<"field1">, int>,
+                            groov::with_value_t<groov::path<"field2">,
+                                                double>>> const>);
 }
 
-TEST_CASE("retrieve values by path", "[identifier]") {
+TEST_CASE("retrieve values by path", "[path]") {
     using namespace groov::literals;
     constexpr auto v = ("field"_f = 5);
     static_assert(v["field"_f] == 5);
 }
 
-TEST_CASE("drill down into value with partial path", "[identifier]") {
+TEST_CASE("drill down into value with partial path", "[path]") {
     using namespace groov::literals;
-    constexpr auto v = ("reg"_r / "field"_f = 5);
+    constexpr auto v = "reg"_r / "field"_f = 5;
     constexpr auto r = v["reg"_r];
     static_assert(
         std::is_same_v<groov::get_path_t<decltype(r)>, decltype("field"_f)>);
     static_assert(r.value == 5);
 }
 
-TEST_CASE("retrieve located value by path", "[identifier]") {
+TEST_CASE("retrieve located value by path", "[path]") {
     using namespace groov::literals;
-    constexpr auto v = ("reg"_r / "field"_f = 5);
+    constexpr auto v = "reg"_r / "field"_f = 5;
     constexpr auto f = v["reg"_r];
     static_assert(
         std::is_same_v<decltype(f),
-                       groov::with_values_t<groov::path<"field">, int> const>);
+                       groov::with_value_t<groov::path<"field">, int> const>);
     static_assert(f["field"_f] == 5);
 }
 
-TEST_CASE("retrieve among multiple located values", "[identifier]") {
+TEST_CASE("retrieve among multiple located values", "[path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r("field1"_f = 5, "field2"_f = 10.0);
     static_assert(v["reg"_r]["field1"_f] == 5);
+    static_assert(v["reg.field2"_f] == 10.0);
 }
 
-TEST_CASE("tree of values", "[identifier]") {
+TEST_CASE("tree of values", "[path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r(
         "field1"_f = 5, "field2"_f("subfield1"_f = 10.0, "subfield2"_f = true));
@@ -167,10 +176,39 @@ TEST_CASE("tree of values", "[identifier]") {
     static_assert(v["reg"_r]["field2"_f]["subfield1"_f] == 10.0);
 }
 
-TEST_CASE("retrieve by path", "[identifier]") {
+TEST_CASE("retrieve by path", "[path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r(
         "field1"_f = 5, "field2"_f("subfield1"_f = 10.0, "subfield2"_f = true));
     static_assert(v["reg.field1"_f] == 5);
     static_assert(v["reg.field2"_f]["subfield1"_f] == 10.0);
+}
+
+TEST_CASE("empty path predicate", "[path]") {
+    using P = groov::path<>;
+    static_assert(std::empty(P{}));
+    using Q = groov::path<"hello">;
+    static_assert(not std::empty(Q{}));
+}
+
+TEST_CASE("path with value can be extended", "[path]") {
+    using namespace groov::literals;
+    constexpr auto v = "reg"_r / ("field"_f = 5);
+    static_assert(std::is_same_v<groov::get_path_t<decltype(v)>,
+                                 decltype("reg.field"_f)>);
+    static_assert(v.value == 5);
+    static_assert(v["reg"_r]["field"_f] == 5);
+}
+
+TEST_CASE("root of a path with value", "[path]") {
+    using namespace groov::literals;
+    constexpr auto v = "reg"_r / "field"_f = 5;
+    static_assert(root(v) == stdx::ct_string{"reg"});
+}
+
+TEST_CASE("path with value without root", "[path]") {
+    using namespace groov::literals;
+    constexpr auto v = "reg"_r / "field"_f = 5;
+    constexpr auto r = without_root(v);
+    static_assert(r["field"_f] == 5);
 }


### PR DESCRIPTION
Do the right thing by paths with values: work in value space for functions like `operator/` and `without_root`. Only one specialization of `with_values_t` is required.