### PR TITLE
:sparkles: Add assignment for write_spec indexing

### DIFF
--- a/test/write.cpp
+++ b/test/write.cpp
@@ -118,7 +118,8 @@ TEST_CASE("piped read-modify-write", "[write]") {
     async::just(grp / "reg0"_r) //
         | groov::read           //
         | async::then([](auto spec) {
-              return grp / ("reg0"_r = spec["reg0"_r] ^ 0xffff'ffff);
+              spec["reg0"_r] ^= 0xffff'ffff;
+              return spec;
           })           //
         | groov::write //
         | async::sync_wait();

--- a/test/write_spec.cpp
+++ b/test/write_spec.cpp
@@ -73,7 +73,7 @@ TEST_CASE("operator/ is overloaded to make write_spec", "[write_spec]") {
 
 TEST_CASE("write spec can be indexed by path", "[write_spec]") {
     using namespace groov::literals;
-    auto spec = grp("reg0"_r = 5);
+    auto const spec = grp("reg0"_r = 5);
     CHECK(spec["reg0"_r] == 5);
 }
 
@@ -103,4 +103,40 @@ TEST_CASE("write spec with only one value implicitly converts",
     using namespace groov::literals;
     auto spec = grp("reg0"_r = 5);
     CHECK(spec == 5);
+}
+
+TEST_CASE("write spec indexing supports assignment", "[write_spec]") {
+    using namespace groov::literals;
+    auto spec = grp("reg0"_r = 5);
+    spec["reg0"_r] = 4;
+    CHECK(spec["reg0"_r] == 4);
+}
+
+TEST_CASE("write spec indexing supports op-assignment", "[write_spec]") {
+    using namespace groov::literals;
+    auto spec = grp("reg0"_r = 5);
+    spec["reg0"_r] += 1;
+    spec["reg0"_r] -= 1;
+    spec["reg0"_r] *= 1;
+    spec["reg0"_r] /= 1;
+    spec["reg0"_r] %= 6;
+    CHECK(spec["reg0"_r] == 5);
+    spec["reg0"_r] &= 3;
+    CHECK(spec["reg0"_r] == 1);
+    spec["reg0"_r] |= 4;
+    CHECK(spec["reg0"_r] == 5);
+    spec["reg0"_r] ^= 4;
+    CHECK(spec["reg0"_r] == 1);
+}
+
+TEST_CASE("write spec indexing supports increment/decrement", "[write_spec]") {
+    using namespace groov::literals;
+    auto spec = grp("reg0"_r = 5);
+    ++spec["reg0"_r];
+    --spec["reg0"_r];
+    CHECK(spec["reg0"_r] == 5);
+
+    CHECK(spec["reg0"_r]++ == 5);
+    CHECK(spec["reg0"_r]-- == 6);
+    CHECK(spec["reg0"_r] == 5);
 }


### PR DESCRIPTION
Problem:
 - Indexing into a `write_spec` produces a read-only object, so we can't do the natural thing: `spec["reg"_r] = value;`

Solution:
 - Return a proxy object from `operator[]` that supports assignment as well as implicit conversion to field type.

Note:
 - Proxies are not moveable, and most of the functions are `const &&` ref-qualified: they are intended for immediate use in expressions, not any kind of storage.