### PR TITLE
:construction_worker: Use a `FILE_SET` for groov headers

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           cache-name: cpm-cache-0
         id: cpm-cache-restore
-        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/cpm-cache
           key: ${{runner.os}}-${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
@@ -69,7 +69,7 @@ jobs:
         env:
           cache-name: cpm-cache-0
         if: steps.cpm-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/cpm-cache
           key: ${{runner.os}}-${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ if(NOT DEFINED CMAKE_CXX_STANDARD)
 endif()
 
 add_library(groov INTERFACE)
-target_include_directories(groov INTERFACE include)
 target_compile_features(groov INTERFACE cxx_std_${CMAKE_CXX_STANDARD})
 target_link_libraries_system(groov INTERFACE async boost_mp11 safe_arithmetic
                              stdx)
@@ -35,6 +34,30 @@ target_compile_options(
     INTERFACE
         $<$<AND:$<CXX_COMPILER_ID:Clang>,$<VERSION_LESS_EQUAL:${CMAKE_CXX_COMPILER_VERSION},14>>:-Wno-gnu-string-literal-operator-template>
 )
+
+target_sources(
+    groov
+    INTERFACE FILE_SET
+              groov
+              TYPE
+              HEADERS
+              BASE_DIRS
+              include
+              FILES
+              include/groov/attach_value.hpp
+              include/groov/boost_extra.hpp
+              include/groov/config.hpp
+              include/groov/groov.hpp
+              include/groov/identity.hpp
+              include/groov/make_spec.hpp
+              include/groov/mmio_bus.hpp
+              include/groov/path.hpp
+              include/groov/read.hpp
+              include/groov/read_spec.hpp
+              include/groov/resolve.hpp
+              include/groov/value_path.hpp
+              include/groov/write.hpp
+              include/groov/write_spec.hpp)
 
 if(PROJECT_IS_TOP_LEVEL)
     add_docs(docs)

--- a/usage_test/main.cpp
+++ b/usage_test/main.cpp
@@ -1,9 +1,9 @@
+#include <groov/groov.hpp>
+
 #include <async/concepts.hpp>
 #include <async/just.hpp>
 #include <async/just_result_of.hpp>
 #include <async/sync_wait.hpp>
-
-#include <groov/groov.hpp>
 
 #include <cassert>
 #include <cstdint>


### PR DESCRIPTION
Problem:
- `groov` use `target_include_directories` rather than using a `FILE_SET` which is the preferred option.
- The usage test does not pass clang-format checks.

Solution:
- Use a `FILE_SET` for `groov` sources.
- Format `usage_test/main.cpp` properly.