### PR TITLE
:white_check_mark: Use `STATIC_REQUIRE` instead of `static_assert`

### DIFF
--- a/test/config.cpp
+++ b/test/config.cpp
@@ -25,14 +25,14 @@ TEST_CASE("fields inside a register", "[config]") {
     using F = groov::field<"field", std::uint32_t, 0, 0>;
     using R = groov::reg<"reg", std::uint32_t, 0, groov::w::replace, F>;
     using X = groov::get_child<R, "field">;
-    static_assert(std::same_as<F, X>);
+    STATIC_REQUIRE(std::same_as<F, X>);
 }
 
 TEST_CASE("registers in a group", "[config]") {
     using R = groov::reg<"reg", std::uint32_t, 0>;
     using G = groov::group<"group", bus, R>;
     using X = groov::get_child<G, "reg">;
-    static_assert(std::same_as<R, X>);
+    STATIC_REQUIRE(std::same_as<R, X>);
 }
 
 TEST_CASE("subfields inside a field", "[config]") {
@@ -40,20 +40,20 @@ TEST_CASE("subfields inside a field", "[config]") {
     using F =
         groov::field<"field", std::uint32_t, 0, 0, groov::w::replace, SubF>;
     using X = groov::get_child<F, "subfield">;
-    static_assert(std::same_as<SubF, X>);
+    STATIC_REQUIRE(std::same_as<SubF, X>);
 }
 
 TEST_CASE("field can be extracted from register value", "[config]") {
     constexpr std::uint32_t value{0b11};
     using F = groov::field<"field", std::uint32_t, 0, 0>;
-    static_assert(F::extract(value) == 1);
+    STATIC_REQUIRE(F::extract(value) == 1);
 }
 
 TEST_CASE("field can resolve a path", "[config]") {
     using namespace groov::literals;
     using F = groov::field<"field", std::uint32_t, 0, 0>;
     constexpr auto r = groov::resolve(F{}, "field"_f);
-    static_assert(std::is_same_v<decltype(r), F const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(r), F const>);
 }
 
 TEST_CASE("field containing subfields can resolve a path", "[config]") {
@@ -62,7 +62,7 @@ TEST_CASE("field containing subfields can resolve a path", "[config]") {
     using F =
         groov::field<"field", std::uint32_t, 0, 0, groov::w::replace, SubF>;
     constexpr auto r = groov::resolve(F{}, "field.subfield"_f);
-    static_assert(std::is_same_v<decltype(r), SubF const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(r), SubF const>);
 }
 
 TEST_CASE("field can resolve an unambiguous subpath", "[config]") {
@@ -71,7 +71,7 @@ TEST_CASE("field can resolve an unambiguous subpath", "[config]") {
     using F =
         groov::field<"field", std::uint32_t, 0, 0, groov::w::replace, SubF>;
     constexpr auto r = groov::resolve(F{}, "subfield"_f);
-    static_assert(std::is_same_v<decltype(r), SubF const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(r), SubF const>);
 }
 
 TEST_CASE("register can resolve a path", "[config]") {
@@ -79,7 +79,7 @@ TEST_CASE("register can resolve a path", "[config]") {
     using F = groov::field<"field", std::uint32_t, 0, 0>;
     using R = groov::reg<"reg", std::uint32_t, 0, groov::w::replace, F>;
     constexpr auto r = groov::resolve(R{}, "reg"_r);
-    static_assert(std::is_same_v<decltype(r), R const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(r), R const>);
 }
 
 TEST_CASE("register can resolve an unambiguous subpath", "[config]") {
@@ -87,7 +87,7 @@ TEST_CASE("register can resolve an unambiguous subpath", "[config]") {
     using F = groov::field<"field", std::uint32_t, 0, 0>;
     using R = groov::reg<"reg", std::uint32_t, 0, groov::w::replace, F>;
     constexpr auto r = groov::resolve(R{}, "field"_f);
-    static_assert(std::is_same_v<decltype(r), F const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(r), F const>);
 }
 
 TEST_CASE("register can resolve an unambiguous nested subpath", "[config]") {
@@ -97,15 +97,15 @@ TEST_CASE("register can resolve an unambiguous nested subpath", "[config]") {
         groov::field<"field", std::uint32_t, 0, 0, groov::w::replace, SubF>;
     using R = groov::reg<"reg", std::uint32_t, 0, groov::w::replace, F>;
     constexpr auto r = groov::resolve(R{}, "subfield"_f);
-    static_assert(std::is_same_v<decltype(r), SubF const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(r), SubF const>);
 }
 
 TEST_CASE("invalid path gives invalid resolution", "[config]") {
     using namespace groov::literals;
     using F = groov::field<"field", std::uint32_t, 0, 0>;
     using R = groov::reg<"reg", std::uint32_t, 0, groov::w::replace, F>;
-    static_assert(std::is_same_v<groov::invalid_t,
-                                 decltype(groov::resolve(R{}, "invalid"_f))>);
+    STATIC_REQUIRE(std::is_same_v<groov::invalid_t,
+                                  decltype(groov::resolve(R{}, "invalid"_f))>);
 }
 
 TEST_CASE("ambiguous subpath gives ambiguous resolution", "[config]") {
@@ -116,8 +116,8 @@ TEST_CASE("ambiguous subpath gives ambiguous resolution", "[config]") {
     using F1 =
         groov::field<"field1", std::uint32_t, 1, 1, groov::w::replace, SubF>;
     using R = groov::reg<"reg", std::uint32_t, 0, groov::w::replace, F0, F1>;
-    static_assert(std::is_same_v<groov::ambiguous_t,
-                                 decltype(groov::resolve(R{}, "subfield"_f))>);
+    STATIC_REQUIRE(std::is_same_v<groov::ambiguous_t,
+                                  decltype(groov::resolve(R{}, "subfield"_f))>);
 }
 
 TEST_CASE("group can resolve a path", "[config]") {
@@ -126,13 +126,13 @@ TEST_CASE("group can resolve a path", "[config]") {
     using R = groov::reg<"reg", std::uint32_t, 0, groov::w::replace, F>;
     using G = groov::group<"group", bus, R>;
     constexpr auto r = groov::resolve(G{}, "reg.field"_f);
-    static_assert(std::is_same_v<decltype(r), F const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(r), F const>);
 }
 
 TEST_CASE("all fields inside a register with no fields", "[config]") {
     using namespace groov::literals;
     using R = groov::reg<"reg", std::uint32_t, 0>;
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<groov::detail::all_fields_t<boost::mp11::mp_list<R>>,
                        boost::mp11::mp_list<R>>);
 }
@@ -142,7 +142,7 @@ TEST_CASE("all fields inside a register with fields", "[config]") {
     using F0 = groov::field<"field0", std::uint32_t, 0, 0>;
     using F1 = groov::field<"field1", std::uint32_t, 1, 1>;
     using R = groov::reg<"reg", std::uint32_t, 0, groov::w::replace, F0, F1>;
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<groov::detail::all_fields_t<boost::mp11::mp_list<R>>,
                        boost::mp11::mp_list<F0, F1>>);
 }
@@ -156,7 +156,7 @@ TEST_CASE("all fields inside a register with fields and subfields",
                             SubF00, SubF01>;
     using F1 = groov::field<"field1", std::uint32_t, 2, 2>;
     using R = groov::reg<"reg", std::uint32_t, 0, groov::w::replace, F0, F1>;
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<groov::detail::all_fields_t<boost::mp11::mp_list<R>>,
                        boost::mp11::mp_list<SubF00, SubF01, F1>>);
 }

--- a/test/identity.cpp
+++ b/test/identity.cpp
@@ -7,53 +7,54 @@
 #include <type_traits>
 
 TEST_CASE("all specs except none fulfil identity_spec", "[identity]") {
-    static_assert(not groov::identity_spec<groov::id::none>);
-    static_assert(groov::identity_spec<groov::id::zero>);
-    static_assert(groov::identity_spec<groov::id::one>);
-    static_assert(groov::identity_spec<groov::id::any>);
+    STATIC_REQUIRE(not groov::identity_spec<groov::id::none>);
+    STATIC_REQUIRE(groov::identity_spec<groov::id::zero>);
+    STATIC_REQUIRE(groov::identity_spec<groov::id::one>);
+    STATIC_REQUIRE(groov::identity_spec<groov::id::any>);
 }
 
 TEST_CASE("zero id spec returns a zeroed identity", "[identity]") {
     constexpr auto i = groov::id::zero::identity<std::uint8_t, 7, 0>();
-    static_assert(i == 0);
+    STATIC_REQUIRE(i == 0);
 }
 
 TEST_CASE("one id spec returns a identity with ones", "[identity]") {
     constexpr auto i = groov::id::one::identity<std::uint8_t, 7, 0>();
-    static_assert(i == 0xffu);
+    STATIC_REQUIRE(i == 0xffu);
 }
 
 TEST_CASE("any id spec returns a zeroed identity", "[identity]") {
     constexpr auto i = groov::id::any::identity<std::uint8_t, 7, 0>();
-    static_assert(i == 0);
+    STATIC_REQUIRE(i == 0);
 }
 
 TEST_CASE("replace write function has no identity", "[identity]") {
-    static_assert(groov::write_function<groov::w::replace>);
-    static_assert(std::is_same_v<groov::w::replace::id_spec, groov::id::none>);
+    STATIC_REQUIRE(groov::write_function<groov::w::replace>);
+    STATIC_REQUIRE(std::is_same_v<groov::w::replace::id_spec, groov::id::none>);
 }
 
 TEST_CASE("read_only write function has any identity", "[identity]") {
-    static_assert(groov::write_function<groov::w::read_only>);
-    static_assert(std::is_same_v<groov::w::read_only::id_spec, groov::id::any>);
+    STATIC_REQUIRE(groov::write_function<groov::w::read_only>);
+    STATIC_REQUIRE(
+        std::is_same_v<groov::w::read_only::id_spec, groov::id::any>);
 }
 
 TEST_CASE("write one to set/clear write function has zero identity",
           "[identity]") {
-    static_assert(groov::write_function<groov::w::one_to_set>);
-    static_assert(groov::write_function<groov::w::one_to_clear>);
-    static_assert(
+    STATIC_REQUIRE(groov::write_function<groov::w::one_to_set>);
+    STATIC_REQUIRE(groov::write_function<groov::w::one_to_clear>);
+    STATIC_REQUIRE(
         std::is_same_v<groov::w::one_to_set::id_spec, groov::id::zero>);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<groov::w::one_to_clear::id_spec, groov::id::zero>);
 }
 
 TEST_CASE("write zero to set/clear write function has one identity",
           "[identity]") {
-    static_assert(groov::write_function<groov::w::zero_to_set>);
-    static_assert(groov::write_function<groov::w::zero_to_clear>);
-    static_assert(
+    STATIC_REQUIRE(groov::write_function<groov::w::zero_to_set>);
+    STATIC_REQUIRE(groov::write_function<groov::w::zero_to_clear>);
+    STATIC_REQUIRE(
         std::is_same_v<groov::w::zero_to_set::id_spec, groov::id::one>);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<groov::w::zero_to_clear::id_spec, groov::id::one>);
 }

--- a/test/path.cpp
+++ b/test/path.cpp
@@ -7,91 +7,91 @@
 TEST_CASE("register literal", "[path]") {
     using namespace groov::literals;
     constexpr auto r = "reg"_r;
-    static_assert(std::is_same_v<decltype(r), groov::path<"reg"> const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(r), groov::path<"reg"> const>);
 }
 
 TEST_CASE("field literal", "[path]") {
     using namespace groov::literals;
     constexpr auto f = "field"_f;
-    static_assert(std::is_same_v<decltype(f), groov::path<"field"> const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(f), groov::path<"field"> const>);
 }
 
 TEST_CASE("dot-separated literal", "[path]") {
     using namespace groov::literals;
     constexpr auto f = "a.b.c.d"_f;
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(f), groov::path<"a", "b", "c", "d"> const>);
 }
 
 TEST_CASE("path concatenation with /", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "reg"_r / "field"_f;
-    static_assert(p == "reg.field"_f);
+    STATIC_REQUIRE(p == "reg.field"_f);
 }
 
 TEST_CASE("path can resolve itself", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "a"_r;
-    static_assert(groov::is_resolvable_v<decltype(p), decltype(p)>);
+    STATIC_REQUIRE(groov::is_resolvable_v<decltype(p), decltype(p)>);
 }
 
 TEST_CASE("path resolves itself to empty path", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "a"_r;
     constexpr auto r = groov::resolve(p, p);
-    static_assert(std::is_same_v<decltype(r), groov::path<> const>);
+    STATIC_REQUIRE(std::is_same_v<decltype(r), groov::path<> const>);
 }
 
 TEST_CASE("path resolves a shorter path", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "a.b.c"_r;
     constexpr auto r1 = groov::resolve(p, "a"_r);
-    static_assert(r1 == "b.c"_r);
+    STATIC_REQUIRE(r1 == "b.c"_r);
     constexpr auto r2 = groov::resolve(p, "a.b"_r);
-    static_assert(r2 == "c"_r);
+    STATIC_REQUIRE(r2 == "c"_r);
 }
 
 TEST_CASE("path doesn't resolve a non-path", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "a.b.c"_r;
-    static_assert(not groov::can_resolve<decltype(p), int>);
+    STATIC_REQUIRE(not groov::can_resolve<decltype(p), int>);
 }
 
 TEST_CASE("mismatched path gives invalid resolution", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "a.b.c"_r;
-    static_assert(std::is_same_v<groov::mismatch_t,
-                                 decltype(groov::resolve(p, "invalid"_r))>);
+    STATIC_REQUIRE(std::is_same_v<groov::mismatch_t,
+                                  decltype(groov::resolve(p, "invalid"_r))>);
 }
 
 TEST_CASE("too-long path gives invalid resolution", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "a.b"_r;
-    static_assert(std::is_same_v<groov::too_long_t,
-                                 decltype(groov::resolve(p, "a.b.c"_r))>);
+    STATIC_REQUIRE(std::is_same_v<groov::too_long_t,
+                                  decltype(groov::resolve(p, "a.b.c"_r))>);
 }
 
 TEST_CASE("root of a path", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "a.b.c"_r;
-    static_assert(root(p) == stdx::ct_string{"a"});
+    STATIC_REQUIRE(root(p) == stdx::ct_string{"a"});
 }
 
 TEST_CASE("path without its root", "[path]") {
     using namespace groov::literals;
     constexpr auto p = "a.b.c"_r;
-    static_assert(without_root(p) == "b.c"_r);
+    STATIC_REQUIRE(without_root(p) == "b.c"_r);
 }
 
 TEST_CASE("empty path predicate", "[path]") {
     using P = groov::path<>;
-    static_assert(std::empty(P{}));
+    STATIC_REQUIRE(std::empty(P{}));
     using Q = groov::path<"hello">;
-    static_assert(not std::empty(Q{}));
+    STATIC_REQUIRE(not std::empty(Q{}));
 }
 
 TEST_CASE("path is pathlike", "[path]") {
     using namespace groov::literals;
-    static_assert(groov::pathlike<decltype("reg"_r / "field"_f)>);
-    static_assert(not groov::valued_pathlike<decltype("reg"_r / "field"_f)>);
+    STATIC_REQUIRE(groov::pathlike<decltype("reg"_r / "field"_f)>);
+    STATIC_REQUIRE(not groov::valued_pathlike<decltype("reg"_r / "field"_f)>);
 }

--- a/test/read_spec.cpp
+++ b/test/read_spec.cpp
@@ -39,7 +39,7 @@ constexpr auto grp = G{};
 TEST_CASE("read_spec is made by combining group and paths", "[read_spec]") {
     using namespace groov::literals;
     auto spec = grp("reg0"_r);
-    static_assert(
+    STATIC_REQUIRE(
         stdx::is_specialization_of_v<decltype(spec), groov::read_spec>);
 }
 
@@ -47,8 +47,8 @@ TEST_CASE("valid paths are captured", "[read_spec]") {
     using namespace groov::literals;
     auto p = "reg0"_r;
     auto spec = grp(p);
-    static_assert(std::is_same_v<decltype(spec)::paths_t,
-                                 boost::mp11::mp_list<decltype(p)>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(spec)::paths_t,
+                                  boost::mp11::mp_list<decltype(p)>>);
 }
 
 TEST_CASE("multiple paths can be passed", "[read_spec]") {
@@ -56,7 +56,7 @@ TEST_CASE("multiple paths can be passed", "[read_spec]") {
     auto p = "reg0"_r;
     auto q = "reg1"_r;
     auto spec = grp(p, q);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(spec)::paths_t,
                        boost::mp11::mp_list<decltype(p), decltype(q)>>);
 }
@@ -65,6 +65,6 @@ TEST_CASE("operator/ is overloaded to make read_spec", "[read_spec]") {
     using namespace groov::literals;
     auto p = "reg0"_r;
     auto spec = grp / p;
-    static_assert(std::is_same_v<decltype(spec)::paths_t,
-                                 boost::mp11::mp_list<decltype(p)>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(spec)::paths_t,
+                                  boost::mp11::mp_list<decltype(p)>>);
 }

--- a/test/tools/test_regs.py
+++ b/test/tools/test_regs.py
@@ -1,5 +1,11 @@
 def test_parse(t):
-    return {'test_regs':
-        groov.Group('test_regs', [
-            groov.Register('test', 0x0, [
-                groov.Field('test', 'groov::w::replace', 0, 0)])])}
+    return {
+        "test_regs": groov.Group(
+            "test_regs",
+            [
+                groov.Register(
+                    "test", 0x0, [groov.Field("test", "groov::w::replace", 0, 0)]
+                )
+            ],
+        )
+    }

--- a/test/value_path.cpp
+++ b/test/value_path.cpp
@@ -8,39 +8,39 @@
 TEST_CASE("path with value (operator=)", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r / "field"_f = 5;
-    static_assert(std::is_same_v<groov::get_path_t<decltype(v)>,
-                                 decltype("reg.field"_f)>);
-    static_assert(v.value == 5);
+    STATIC_REQUIRE(std::is_same_v<groov::get_path_t<decltype(v)>,
+                                  decltype("reg.field"_f)>);
+    STATIC_REQUIRE(v.value == 5);
 }
 
 TEST_CASE("path with value (operator())", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r(5);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<groov::get_path_t<decltype(v)>, decltype("reg"_f)>);
-    static_assert(v.value == 5);
+    STATIC_REQUIRE(v.value == 5);
 }
 
 TEST_CASE("path with value can resolve path", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r / "field"_f = 5;
     constexpr auto r = groov::resolve(v, "reg"_r);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<groov::get_path_t<decltype(r)>, decltype("field"_f)>);
-    static_assert(r.value == 5);
+    STATIC_REQUIRE(r.value == 5);
 }
 
 TEST_CASE("mismatched path gives invalid resolution", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r / "field"_f = 5;
-    static_assert(std::is_same_v<groov::mismatch_t,
-                                 decltype(groov::resolve(v, "invalid"_r))>);
+    STATIC_REQUIRE(std::is_same_v<groov::mismatch_t,
+                                  decltype(groov::resolve(v, "invalid"_r))>);
 }
 
 TEST_CASE("too-long path gives invalid resolution", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r / "field"_f = 5;
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<groov::too_long_t,
                        decltype(groov::resolve(v, "reg.field.foo"_r))>);
 }
@@ -48,14 +48,14 @@ TEST_CASE("too-long path gives invalid resolution", "[value_path]") {
 TEST_CASE("ambiguous path gives invalid resolution", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r("field"_f = 5, "field"_f = 6);
-    static_assert(std::is_same_v<groov::ambiguous_t,
-                                 decltype(groov::resolve(v, "reg.field"_r))>);
+    STATIC_REQUIRE(std::is_same_v<groov::ambiguous_t,
+                                  decltype(groov::resolve(v, "reg.field"_r))>);
 }
 
 TEST_CASE("register with multiple field values", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r("field1"_f = 5, "field2"_f = 10.0);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<
             decltype(v),
             groov::value_path<
@@ -68,82 +68,82 @@ TEST_CASE("register with multiple field values", "[value_path]") {
 TEST_CASE("retrieve values by path", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = ("field"_f = 5);
-    static_assert(v["field"_f] == 5);
+    STATIC_REQUIRE(v["field"_f] == 5);
 }
 
 TEST_CASE("drill down into value with partial path", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r / "field"_f = 5;
     constexpr auto r = v["reg"_r];
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<groov::get_path_t<decltype(r)>, decltype("field"_f)>);
-    static_assert(r.value == 5);
+    STATIC_REQUIRE(r.value == 5);
 }
 
 TEST_CASE("retrieve located value by path", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r / "field"_f = 5;
     constexpr auto f = v["reg"_r];
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(f),
                        groov::value_path<groov::path<"field">, int> const>);
-    static_assert(f["field"_f] == 5);
+    STATIC_REQUIRE(f["field"_f] == 5);
 }
 
 TEST_CASE("retrieve among multiple located values", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r("field1"_f = 5, "field2"_f = 10.0);
-    static_assert(v["reg"_r]["field1"_f] == 5);
-    static_assert(v["reg.field2"_f] == 10.0);
+    STATIC_REQUIRE(v["reg"_r]["field1"_f] == 5);
+    STATIC_REQUIRE(v["reg.field2"_f] == 10.0);
 }
 
 TEST_CASE("tree of values", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r(
         "field1"_f = 5, "field2"_f("subfield1"_f = 10.0, "subfield2"_f = true));
-    static_assert(v["reg"_r]["field1"_f] == 5);
-    static_assert(v["reg"_r]["field2"_f]["subfield1"_f] == 10.0);
+    STATIC_REQUIRE(v["reg"_r]["field1"_f] == 5);
+    STATIC_REQUIRE(v["reg"_r]["field2"_f]["subfield1"_f] == 10.0);
 }
 
 TEST_CASE("retrieve by path", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r(
         "field1"_f = 5, "field2"_f("subfield1"_f = 10.0, "subfield2"_f = true));
-    static_assert(v["reg.field1"_f] == 5);
-    static_assert(v["reg.field2"_f]["subfield1"_f] == 10.0);
+    STATIC_REQUIRE(v["reg.field1"_f] == 5);
+    STATIC_REQUIRE(v["reg.field2"_f]["subfield1"_f] == 10.0);
 }
 
 TEST_CASE("path with value can be extended", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r / ("field"_f = 5);
-    static_assert(std::is_same_v<groov::get_path_t<decltype(v)>,
-                                 decltype("reg.field"_f)>);
-    static_assert(v.value == 5);
-    static_assert(v["reg"_r]["field"_f] == 5);
+    STATIC_REQUIRE(std::is_same_v<groov::get_path_t<decltype(v)>,
+                                  decltype("reg.field"_f)>);
+    STATIC_REQUIRE(v.value == 5);
+    STATIC_REQUIRE(v["reg"_r]["field"_f] == 5);
 }
 
 TEST_CASE("path (with value) equals (path with) value ", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v1 = "reg"_r / ("field"_f = 5);
     constexpr auto v2 = ("reg"_r / "field"_f) = 5;
-    static_assert(v1 == v2);
+    STATIC_REQUIRE(v1 == v2);
 }
 
 TEST_CASE("root of a path with value", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r / "field"_f = 5;
-    static_assert(root(v) == stdx::ct_string{"reg"});
+    STATIC_REQUIRE(root(v) == stdx::ct_string{"reg"});
 }
 
 TEST_CASE("path with value without root", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r / "field"_f = 5;
     constexpr auto r = without_root(v);
-    static_assert(r["field"_f] == 5);
+    STATIC_REQUIRE(r["field"_f] == 5);
 }
 
 TEST_CASE("path with value is valued_pathlike", "[value_path]") {
     using namespace groov::literals;
-    static_assert(groov::pathlike<decltype("reg"_r / "field"_f = 5)>);
-    static_assert(groov::valued_pathlike<decltype("reg"_r / "field"_f = 5)>);
+    STATIC_REQUIRE(groov::pathlike<decltype("reg"_r / "field"_f = 5)>);
+    STATIC_REQUIRE(groov::valued_pathlike<decltype("reg"_r / "field"_f = 5)>);
 }

--- a/test/write_spec.cpp
+++ b/test/write_spec.cpp
@@ -40,7 +40,7 @@ constexpr auto grp = G{};
 TEST_CASE("write_spec is made by combining group and paths", "[write_spec]") {
     using namespace groov::literals;
     auto spec = grp("reg0"_r = 5);
-    static_assert(
+    STATIC_REQUIRE(
         stdx::is_specialization_of_v<decltype(spec), groov::write_spec>);
 }
 
@@ -48,7 +48,7 @@ TEST_CASE("valid paths are captured", "[write_spec]") {
     using namespace groov::literals;
     auto p = "reg0"_r = 5;
     auto spec = grp(p);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(spec)::paths_t,
                        boost::mp11::mp_list<typename decltype(p)::path_t>>);
 }
@@ -58,7 +58,7 @@ TEST_CASE("multiple paths can be passed", "[write_spec]") {
     auto p = "reg0"_r = 5;
     auto q = "reg1"_r = 6;
     auto spec = grp(p, q);
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(spec)::paths_t,
                        boost::mp11::mp_list<typename decltype(p)::path_t,
                                             typename decltype(q)::path_t>>);
@@ -68,7 +68,7 @@ TEST_CASE("operator/ is overloaded to make write_spec", "[write_spec]") {
     using namespace groov::literals;
     auto p = "reg0"_r = 5;
     auto spec = grp / p;
-    static_assert(
+    STATIC_REQUIRE(
         std::is_same_v<decltype(spec)::paths_t,
                        boost::mp11::mp_list<typename decltype(p)::path_t>>);
 }

--- a/tools/groov.py
+++ b/tools/groov.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 
 
-Group = namedtuple('Group', ['name', 'registers'])
-Register = namedtuple('Register', ['name', 'address', 'fields'])
-Field = namedtuple('Field', ['name', 'access', 'msb', 'lsb'])
+Group = namedtuple("Group", ["name", "registers"])
+Register = namedtuple("Register", ["name", "address", "fields"])
+Field = namedtuple("Field", ["name", "access", "msb", "lsb"])

--- a/tools/parse_svd.py
+++ b/tools/parse_svd.py
@@ -2,35 +2,35 @@ def parse_svd(filename):
     import groov
     import re
     import xml.etree.ElementTree as et
-    
+
     def mk_field(x):
-        (msb, lsb) = re.search(r"\[(\d+):(\d+)\]", x.find('bitRange').text).groups()
+        (msb, lsb) = re.search(r"\[(\d+):(\d+)\]", x.find("bitRange").text).groups()
 
         return groov.Field(
-            name = x.find('name').text,
-            access = x.find('access').text,
-            msb = int(msb),
-            lsb = int(lsb)
+            name=x.find("name").text,
+            access=x.find("access").text,
+            msb=int(msb),
+            lsb=int(lsb),
         )
 
     def mk_register(x, base):
         return groov.Register(
-            name = x.find('name').text,
-            address = base + int(x.find('addressOffset').text, 16),
-            fields = [mk_field(f) for f in x.findall('.//field')]
+            name=x.find("name").text,
+            address=base + int(x.find("addressOffset").text, 16),
+            fields=[mk_field(f) for f in x.findall(".//field")],
         )
 
     def mk_group(x, root):
-        base_addr = int(x.find('baseAddress').text, 16)
-        name = x.find('name').text
+        base_addr = int(x.find("baseAddress").text, 16)
+        name = x.find("name").text
 
-        if ("derivedFrom" in x.attrib):
+        if "derivedFrom" in x.attrib:
             x = root.find(f""".//peripheral[name='{x.attrib["derivedFrom"]}']""")
-            
+
         return groov.Group(
-            name = name,
-            registers = [mk_register(r, base_addr) for r in x.findall('.//register')]
+            name=name,
+            registers=[mk_register(r, base_addr) for r in x.findall(".//register")],
         )
-    
+
     root = et.parse(filename).getroot()
-    return [mk_group(p, root) for p in root.findall('.//peripheral')]
+    return [mk_group(p, root) for p in root.findall(".//peripheral")]

--- a/tools/regs2groov.py
+++ b/tools/regs2groov.py
@@ -11,12 +11,8 @@ def select_name_func(choice):
 
     def keep(s):
         return s
-    
-    return dict(
-        keep = keep,
-        lower = to_lower,
-        upper = to_upper
-    )[choice]
+
+    return dict(keep=keep, lower=to_lower, upper=to_upper)[choice]
 
 
 # def generate_groups(groups, ):
@@ -30,14 +26,14 @@ def generate_groups(groups, config):
         if lines:
             prefix = "\n" + (" " * len)
             infix = "," + prefix
-            return infix + infix.join(lines) 
+            return infix + infix.join(lines)
         else:
             return ""
 
     def to_integral_type(bit_width):
         if bit_width == 1:
             return "bool"
-        
+
         for i in [8, 16, 32, 64]:
             if bit_width <= i:
                 return f"std::uint_fast{i}_t"
@@ -47,11 +43,11 @@ def generate_groups(groups, config):
         return f"""groov::field<"{name_func(f.name)}", {integral_type}, {f.msb}u, {f.lsb}u, {f.access}>"""
 
     def generate_register(r):
-        fields = indent([generate_field(f) for f in r.fields], len = 12)
+        fields = indent([generate_field(f) for f in r.fields], len=12)
         return f"""groov::reg<"{name_func(r.name)}", std::uint32_t, {hex(r.address)}u{fields}>"""
-    
+
     def generate_group(g):
-        registers = indent([generate_register(r) for r in g.registers], len = 8)
+        registers = indent([generate_register(r) for r in g.registers], len=8)
         return f"""constexpr auto {name_func(g.name)} = \n    groov::group<"{name_func(g.name)}", {bus_type}{registers}>{{}};\n"""
 
     with open(f"{config.output}", "w") as f:
@@ -77,7 +73,9 @@ def generate(config):
     groups = parse_fn(config.input)
     generate_groups(groups, config)
 
+
 # Below this line is just for use as a script
+
 
 def parse_cmdline():
     parser = argparse.ArgumentParser()
@@ -88,18 +86,23 @@ def parse_cmdline():
         help="Specify a custom bus interface for register groups to use.",
     )
     parser.add_argument(
-        "--group", type=str, required=True, help="Name of the register group to generate."
+        "--group",
+        type=str,
+        required=True,
+        help="Name of the register group to generate.",
     )
     parser.add_argument(
         "--input",
         type=str,
         required=True,
-        help=(
-            "Full path to file with register definitions."
-        ),
+        help=("Full path to file with register definitions."),
     )
     parser.add_argument(
-        "--includes", type=str, nargs='*', default=[], help="One or more include files to add."
+        "--includes",
+        type=str,
+        nargs="*",
+        default=[],
+        help="One or more include files to add.",
     )
     parser.add_argument(
         "--namespace",
@@ -111,7 +114,7 @@ def parse_cmdline():
         "--naming",
         type=str,
         default="keep",
-        choices=['keep', 'lower', 'upper'],
+        choices=["keep", "lower", "upper"],
         help="How to represent names in the C++ code.",
     )
     parser.add_argument(
@@ -121,10 +124,14 @@ def parse_cmdline():
         "--parse-fn", type=str, help="Name of the parse function to use."
     )
     parser.add_argument(
-        "--parser-modules", type=str, nargs='*', default=[], help="Path(s) to Python module(s) with parse function(s): parse_fn_name(filename: str) -> [Group]."
+        "--parser-modules",
+        type=str,
+        nargs="*",
+        default=[],
+        help="Path(s) to Python module(s) with parse function(s): parse_fn_name(filename: str) -> [Group].",
     )
     parser.add_argument(
-        "--registers", type=str, nargs='+', default=[], help="Registers to generate."
+        "--registers", type=str, nargs="+", default=[], help="Registers to generate."
     )
 
     return parser.parse_args()
@@ -134,6 +141,6 @@ def main():
     args = parse_cmdline()
     generate(args)
 
+
 if __name__ == "__main__":
     main()
-    


### PR DESCRIPTION
Problem:
- Using static_assert does not report the check in Catch2.

Solution:
- Use STATIC_REQUIRE so that the check is reported.