### PR TITLE
:bug: Fix writing to registers whose size is less than `sizeof(int)`

### DIFF
--- a/include/groov/config.hpp
+++ b/include/groov/config.hpp
@@ -117,7 +117,8 @@ struct field : named_container<Name, SubFields...> {
 
     template <std::unsigned_integral RegType>
     constexpr static auto insert(RegType &dest, type_t value) -> void {
-        dest = (dest & ~mask<RegType>) | (static_cast<RegType>(value) << Lsb);
+        dest = static_cast<RegType>((dest & ~mask<RegType>) |
+                                    (static_cast<RegType>(value) << Lsb));
     }
 
     template <pathlike P> constexpr static auto resolve(P p) {

--- a/include/groov/write.hpp
+++ b/include/groov/write.hpp
@@ -10,8 +10,6 @@
 
 #include <boost/mp11/algorithm.hpp>
 
-template <typename...> struct undef;
-
 namespace groov {
 namespace detail {
 template <typename Register, typename Spec, typename Mask, typename IdMask,


### PR DESCRIPTION
Problem:
- Because of integer promotion rules, writing to register can provoke a warning when the register is less than 32 bits.

Solution:
- Add tests for reading and writing 8-bit values; solve integer promotion with an appropriate `static_cast`.