### PR TITLE
:sparkles: Add read-only capability for fields

### DIFF
--- a/docs/write_functions.adoc
+++ b/docs/write_functions.adoc
@@ -207,3 +207,25 @@ static auto write(auto addr, auto value) -> async::sender auto {
 
 The result of this is that when we write to the `enable` field, the other bits
 of the register get written correctly.
+
+=== Read-only fields
+
+A field may be denoted read-only by marking its write function as such:
+
+[source,cpp]
+----
+using FR = groov::field<"reserved", std::uint8_t, 1, 1, groov::read_only<groov::w::ignore>>;
+----
+
+If a field is marked read-only, it's a compile-time error to attempt to assign it a value:
+
+[source,cpp]
+----
+groov::write(G{}("reg.reserved"_f = 1)) | async::sync_wait();
+// compile error: "Attempting to write to a read-only field: reserved"
+----
+
+A write function wrapped with `read_only` in this way must have an `id_spec` that
+provides its identity bits. When the register containing a read-only field is
+written, the bits provided by the `id_spec` for the read-only field(s) will be
+used.

--- a/include/groov/identity.hpp
+++ b/include/groov/identity.hpp
@@ -86,4 +86,16 @@ struct zero_to_clear {
     using id_spec = id::one;
 };
 } // namespace w
+
+template <typename T>
+concept identity_write_function =
+    write_function<T> and identity_spec<typename T::id_spec>;
+
+template <identity_write_function T> struct read_only : T {
+    using read_only_t = int;
+};
+
+template <typename T>
+concept read_only_write_function =
+    identity_write_function<T> and requires { typename T::read_only_t; };
 } // namespace groov

--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -12,4 +12,20 @@ add_fail_tests(
     path_mismatch
     path_too_long
     read_ambiguous_path
-    read_invalid_path)
+    read_invalid_path
+    read_only_field_without_identity)
+
+function(add_formatted_error_tests)
+    add_fail_tests(write_read_only_field)
+endfunction()
+
+if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 20)
+    if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"
+       AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 15)
+        add_formatted_error_tests()
+    endif()
+    if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION}
+                                                   VERSION_GREATER_EQUAL 13.2)
+        add_formatted_error_tests()
+    endif()
+endif()

--- a/test/fail/read_only_field_without_identity.cpp
+++ b/test/fail/read_only_field_without_identity.cpp
@@ -1,0 +1,13 @@
+#include <groov/config.hpp>
+#include <groov/identity.hpp>
+
+#include <cstdint>
+
+// EXPECT: constraints not satisfied
+
+namespace {
+using F = groov::field<"field", std::uint8_t, 0, 0,
+                       groov::read_only<groov::w::replace>>;
+} // namespace
+
+auto main() -> int {}

--- a/test/fail/write_read_only_field.cpp
+++ b/test/fail/write_read_only_field.cpp
@@ -1,0 +1,46 @@
+#include <groov/config.hpp>
+#include <groov/identity.hpp>
+#include <groov/path.hpp>
+#include <groov/value_path.hpp>
+#include <groov/write.hpp>
+#include <groov/write_spec.hpp>
+
+#include <async/concepts.hpp>
+#include <async/just_result_of.hpp>
+#include <async/sync_wait.hpp>
+
+#include <cstdint>
+
+// EXPECT: Attempting to write to a read-only field: field
+
+namespace {
+struct bus {
+    struct dummy_sender {
+        using is_sender = void;
+    };
+    template <auto> static auto read(auto...) -> async::sender auto {
+        return dummy_sender{};
+    }
+
+    template <auto Mask, auto IdMask, auto IdValue>
+    static auto write(auto addr, auto value) -> async::sender auto {
+        return async::just_result_of([=] { *addr = (*addr & ~Mask) | value; });
+    }
+};
+
+using F = groov::field<"field", std::uint8_t, 0, 0,
+                       groov::read_only<groov::w::ignore>>;
+
+std::uint32_t data{};
+using R = groov::reg<"reg", std::uint32_t, &data, groov::w::replace, F>;
+using G = groov::group<"group", bus, R>;
+
+template <typename T> auto sync_write(T const &t) {
+    return groov::write(t) | async::sync_wait();
+}
+} // namespace
+
+auto main() -> int {
+    using namespace groov::literals;
+    sync_write(G{}("reg.field"_f = 1));
+}

--- a/test/write_functions.cpp
+++ b/test/write_functions.cpp
@@ -50,9 +50,11 @@ struct custom_field_func {
     };
 };
 
-using F0 = groov::field<"reserved0", std::uint8_t, 0, 0, groov::w::ignore>;
+using F0 = groov::field<"reserved0", std::uint8_t, 0, 0,
+                        groov::read_only<groov::w::ignore>>;
 using F1 = groov::field<"field", std::uint8_t, 1, 1>;
-using F2 = groov::field<"reserved1", std::uint8_t, 7, 2, custom_field_func>;
+using F2 = groov::field<"reserved1", std::uint8_t, 7, 2,
+                        groov::read_only<custom_field_func>>;
 
 std::uint32_t data{};
 using R =


### PR DESCRIPTION
Problem:
- Fields cannot be marked as read-only at the API level.

Solution:
- Add `read_only<>` to mark a field as read-only.
- `read_only` fields must have write functions with identity values. The identity bits will be written when the register containing the field is written.
- Attempting to set a value in a `read_only` field is a compile-time error.