### PR TITLE
:bug: Use register write function for bits outside fields

### DIFF
--- a/docs/write_functions.adoc
+++ b/docs/write_functions.adoc
@@ -208,6 +208,10 @@ static auto write(auto addr, auto value) -> async::sender auto {
 The result of this is that when we write to the `enable` field, the other bits
 of the register get written correctly.
 
+NOTE: If a register has bits that are not addressed by any fields, the identity
+values for those fields will be taken from the write function on the register
+itself.
+
 === Read-only fields
 
 A field may be denoted read-only by marking its write function as such:

--- a/include/groov/identity.hpp
+++ b/include/groov/identity.hpp
@@ -14,9 +14,7 @@
 namespace groov {
 template <typename T>
 concept identity_spec = requires {
-    {
-        T::template identity<unsigned int, std::size_t{}, std::size_t{}>()
-    } -> std::same_as<unsigned int>;
+    { T::template identity<std::size_t{}>() } -> std::same_as<std::size_t>;
 };
 
 namespace detail {
@@ -30,11 +28,10 @@ constexpr auto compute_identity_mask() {
     }
 }
 
-template <typename I, std::unsigned_integral T, std::size_t Msb,
-          std::size_t Lsb>
+template <typename I, std::unsigned_integral T, T Mask>
 constexpr auto compute_identity() {
     if constexpr (identity_spec<I>) {
-        return I::template identity<T, Msb, Lsb>();
+        return I::template identity<Mask>();
     } else {
         return T{};
     }
@@ -44,20 +41,17 @@ constexpr auto compute_identity() {
 namespace id {
 struct none {};
 struct zero {
-    template <std::unsigned_integral T, std::size_t, std::size_t>
-    constexpr static auto identity() -> T {
+    template <auto Mask> constexpr static auto identity() -> decltype(Mask) {
         return {};
     }
 };
 struct one {
-    template <std::unsigned_integral T, std::size_t Msb, std::size_t Lsb>
-    constexpr static auto identity() -> T {
-        return stdx::bit_mask<T, Msb, Lsb>();
+    template <auto Mask> constexpr static auto identity() -> decltype(Mask) {
+        return Mask;
     }
 };
 struct any {
-    template <std::unsigned_integral T, std::size_t, std::size_t>
-    constexpr static auto identity() -> T {
+    template <auto Mask> constexpr static auto identity() -> decltype(Mask) {
         return {};
     }
 };

--- a/test/identity.cpp
+++ b/test/identity.cpp
@@ -14,17 +14,17 @@ TEST_CASE("all specs except none fulfil identity_spec", "[identity]") {
 }
 
 TEST_CASE("zero id spec returns a zeroed identity", "[identity]") {
-    constexpr auto i = groov::id::zero::identity<std::uint8_t, 7, 0>();
+    constexpr auto i = groov::id::zero::identity<std::uint8_t{0xffu}>();
     STATIC_REQUIRE(i == 0);
 }
 
 TEST_CASE("one id spec returns a identity with ones", "[identity]") {
-    constexpr auto i = groov::id::one::identity<std::uint8_t, 7, 0>();
+    constexpr auto i = groov::id::one::identity<std::uint8_t{0xffu}>();
     STATIC_REQUIRE(i == 0xffu);
 }
 
 TEST_CASE("any id spec returns a zeroed identity", "[identity]") {
-    constexpr auto i = groov::id::any::identity<std::uint8_t, 7, 0>();
+    constexpr auto i = groov::id::any::identity<std::uint8_t{0xffu}>();
     STATIC_REQUIRE(i == 0);
 }
 


### PR DESCRIPTION
Problem:
- When a register has bits that aren't covered by any fields, their identity value(s) are assumed to be zero, when in fact they should be taken from the register's write function.

Solution:
- Compute register identity bits from the register's write function.