### PR TITLE
:children_crossing: Work around clang bug with `consteval` UDLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#0ddce52")
-add_versioned_package("gh:intel/cpp-std-extensions#7e1cbc7")
+add_versioned_package("gh:intel/cpp-std-extensions#effadd4")
 add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#22c8006")
 
 find_package(Python3 COMPONENTS Interpreter)

--- a/include/groov/path.hpp
+++ b/include/groov/path.hpp
@@ -76,30 +76,36 @@ CONSTEVAL auto make_path() -> pathlike auto {
 } // namespace detail
 
 #if __clang__ && __clang_major__ <= 14
-template <class T, T... chars> CONSTEVAL auto operator""_g() -> pathlike auto {
+template <class T, T... chars>
+CONSTEVAL_UDL auto operator""_g() -> pathlike auto {
     constexpr auto s = stdx::ct_string<sizeof...(chars) + 1U>{{chars..., 0}};
     return detail::make_path<s>();
 }
 
-template <class T, T... chars> CONSTEVAL auto operator""_r() -> pathlike auto {
+template <class T, T... chars>
+CONSTEVAL_UDL auto operator""_r() -> pathlike auto {
     constexpr auto s = stdx::ct_string<sizeof...(chars) + 1U>{{chars..., 0}};
     return detail::make_path<s>();
 }
 
-template <class T, T... chars> CONSTEVAL auto operator""_f() -> pathlike auto {
+template <class T, T... chars>
+CONSTEVAL_UDL auto operator""_f() -> pathlike auto {
     constexpr auto s = stdx::ct_string<sizeof...(chars) + 1U>{{chars..., 0}};
     return detail::make_path<s>();
 }
 #else
-template <stdx::ct_string S> CONSTEVAL auto operator""_g() -> pathlike auto {
+template <stdx::ct_string S>
+CONSTEVAL_UDL auto operator""_g() -> pathlike auto {
     return detail::make_path<S>();
 }
 
-template <stdx::ct_string S> CONSTEVAL auto operator""_r() -> pathlike auto {
+template <stdx::ct_string S>
+CONSTEVAL_UDL auto operator""_r() -> pathlike auto {
     return detail::make_path<S>();
 }
 
-template <stdx::ct_string S> CONSTEVAL auto operator""_f() -> pathlike auto {
+template <stdx::ct_string S>
+CONSTEVAL_UDL auto operator""_f() -> pathlike auto {
     return detail::make_path<S>();
 }
 #endif


### PR DESCRIPTION
Problem:
- clang has a persistent regression where it ICEs with the error "trying to emit a call to an immediate function". This seems to be provoked by `consteval` UDLs.

Solution:
- When using clang, mark UDLs as `constexpr` rather than `consteval`.