### PR TITLE
:sparkles: Add `read_sync` and `write_sync`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@ else()
 endif()
 
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
-add_versioned_package("gh:intel/cpp-baremetal-concurrency#0ddce52")
-add_versioned_package("gh:intel/cpp-std-extensions#effadd4")
-add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#22c8006")
+add_versioned_package("gh:intel/cpp-baremetal-concurrency#9d6573a")
+add_versioned_package("gh:intel/cpp-std-extensions#73e1d48")
+add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#8d87a4b")
 
 find_package(Python3 COMPONENTS Interpreter)
 

--- a/docs/read_write.adoc
+++ b/docs/read_write.adoc
@@ -74,8 +74,19 @@ Read can also be piped in a chain of senders.
 
 [source,cpp]
 ----
-auto r = async::just(grp / "reg"_r) | groov::read | async::sync_wait();
+auto r = async::just(grp / "reg"_r) | groov::read() | async::sync_wait();
 ----
+
+To do a simple read from a bus that is synchronous (e.g. an MMIO bus),
+`sync_read` may be called:
+
+[source,cpp]
+----
+auto r = async::just(grp / "reg"_r) | groov::sync_read();
+----
+
+NOTE: `sync_read` automatically assumes that the operation will succeed and
+returns the resulting `write_spec`.
 
 === Write
 
@@ -97,11 +108,22 @@ Write can also be piped in a chain of senders.
 
 [source,cpp]
 ----
-auto r = async::just(grp("reg"_r = 42)) | groov::write | async::sync_wait();
+auto r = async::just(grp("reg"_r = 42)) | groov::write() | async::sync_wait();
 ----
 
-NOTE: `read` and `write` are function objects, hence in a chain they appear as
-e.g. `groov::read` rather than `groov::read()`.
+To do a simple write to a bus that is synchronous (e.g. an MMIO bus),
+`sync_write` may be called:
+
+[source,cpp]
+----
+auto r = async::just(grp("reg"_r = 42)) | groov::sync_write();
+----
+
+The return value here is as for
+https://intel.github.io/cpp-baremetal-senders-and-receivers/#_sync_wait[`async::sync_wait`]:
+a `std::optional<stdx::tuple<T>>` where `T` is whatever is sent by the bus
+`write` function. A disengaged optional means that the write completed with an
+error (although this should not happen for an MMIO write).
 
 Because `read` sends a `write_spec`, a read-modify-write can be achieved with
 piping:
@@ -109,11 +131,11 @@ piping:
 [source,cpp]
 ----
 async::just(grp / "reg"_r)
-    | groov::read
+    | groov::read()
     | async::then(
       [](auto spec) { spec["reg"_r] ^= 0xffff'ffff;
                       return spec; })
-    | groov::write
+    | groov::write()
     | async::sync_wait();
 ----
 

--- a/include/groov/config.hpp
+++ b/include/groov/config.hpp
@@ -289,4 +289,7 @@ template <typename ObjList>
 using all_fields_t = boost::mp11::mp_back<boost::mp11::mp_iterate<
     ObjList, boost::mp11::mp_identity_t, maybe_expand_children>>;
 } // namespace detail
+
+struct blocking;
+struct non_blocking;
 } // namespace groov

--- a/include/groov/read.hpp
+++ b/include/groov/read.hpp
@@ -7,6 +7,7 @@
 
 #include <async/concepts.hpp>
 #include <async/let_value.hpp>
+#include <async/sync_wait.hpp>
 #include <async/then.hpp>
 #include <async/when_all.hpp>
 
@@ -25,34 +26,65 @@ auto read() -> async::sender auto {
 }
 } // namespace detail
 
-constexpr inline struct read_t {
-    template <typename Group, typename Paths>
-    auto operator()(read_spec<Group, Paths> const &s) const -> async::sender
-        auto {
-        using Spec = decltype(to_write_spec(s));
+template <typename Group, typename Paths>
+constexpr auto read(read_spec<Group, Paths> const &s) -> async::sender auto {
+    using Spec = decltype(to_write_spec(s));
 
-        using register_values_t =
-            boost::mp11::mp_apply<boost::mp11::mp_list, typename Spec::value_t>;
-        using field_masks_t = boost::mp11::mp_transform_q<
-            detail::field_mask_for_reg_q<typename Spec::paths_t>,
-            register_values_t>;
+    using register_values_t =
+        boost::mp11::mp_apply<boost::mp11::mp_list, typename Spec::value_t>;
+    using field_masks_t = boost::mp11::mp_transform_q<
+        detail::field_mask_for_reg_q<typename Spec::paths_t>,
+        register_values_t>;
 
-        return []<typename... Rs, typename... Ms>(boost::mp11::mp_list<Rs...>,
-                                                  boost::mp11::mp_list<Ms...>) {
-            return async::when_all(detail::read<Rs, Group, Ms>()...) |
-                   async::then([](typename Rs::type_t... values) {
-                       return Spec{{}, {Rs{{}, values}...}};
-                   });
-        }(register_values_t{}, field_masks_t{});
-    }
+    return []<typename... Rs, typename... Ms>(boost::mp11::mp_list<Rs...>,
+                                              boost::mp11::mp_list<Ms...>) {
+        return async::when_all(detail::read<Rs, Group, Ms>()...) |
+               async::then([](typename Rs::type_t... values) {
+                   return Spec{{}, {Rs{{}, values}...}};
+               });
+    }(register_values_t{}, field_masks_t{});
+}
 
+namespace _read {
+struct pipeable {
   private:
     template <async::sender S>
-    friend constexpr auto operator|(S &&s, read_t self) -> async::sender auto {
+    friend constexpr auto operator|(S &&s, pipeable) -> async::sender auto {
         return std::forward<S>(s) |
-               async::let_value([=]<typename Spec>(Spec &&spec) {
-                   return self(std::forward<Spec>(spec));
+               async::let_value([]<typename Spec>(Spec &&spec) {
+                   return read(std::forward<Spec>(spec));
                });
     }
-} read{};
+};
+} // namespace _read
+
+constexpr auto read() -> _read::pipeable { return {}; }
+
+namespace _sync_read {
+template <typename Behavior, async::sender S> [[nodiscard]] auto wait(S &&s) {
+    static_assert(async::trivially_sync_waitable<S> or
+                      std::is_same_v<Behavior, blocking>,
+                  "sync_read() would block: if you really want this, use "
+                  "sync_read<blocking>()");
+    return get<0>(*(std::forward<S>(s) | async::sync_wait()));
+}
+
+template <typename Behavior> struct pipeable {
+  private:
+    template <async::sender S>
+    friend constexpr auto operator|(S &&s, pipeable) -> decltype(auto) {
+        return wait<Behavior>(std::forward<S>(s) | read());
+    }
+};
+} // namespace _sync_read
+
+template <typename Behavior = non_blocking, typename T>
+[[nodiscard]] auto sync_read(T const &t) {
+    return _sync_read::wait<Behavior>(read(t));
+}
+
+template <typename Behavior = non_blocking>
+[[nodiscard]] auto sync_read() -> _sync_read::pipeable<Behavior> {
+    return {};
+}
 } // namespace groov

--- a/include/groov/write.hpp
+++ b/include/groov/write.hpp
@@ -5,6 +5,7 @@
 
 #include <async/concepts.hpp>
 #include <async/let_value.hpp>
+#include <async/sync_wait.hpp>
 #include <async/when_all.hpp>
 
 #include <stdx/compiler.hpp>
@@ -62,74 +63,103 @@ template <typename L> CONSTEVAL auto check_read_only() -> void {
 }
 } // namespace detail
 
-constexpr inline struct write_t {
-    template <typename Spec>
-    auto operator()(Spec const &s) const -> async::sender auto {
-        using fields_per_reg_t = boost::mp11::mp_transform_q<
-            detail::fields_for_reg_q<typename Spec::paths_t>,
-            typename Spec::value_t>;
+template <typename Spec> auto write(Spec const &s) -> async::sender auto {
+    using fields_per_reg_t = boost::mp11::mp_transform_q<
+        detail::fields_for_reg_q<typename Spec::paths_t>,
+        typename Spec::value_t>;
 
-        using written_fields_per_reg_t =
-            boost::mp11::mp_transform<detail::all_fields_t, fields_per_reg_t>;
-        detail::check_read_only<written_fields_per_reg_t>();
+    using written_fields_per_reg_t =
+        boost::mp11::mp_transform<detail::all_fields_t, fields_per_reg_t>;
+    detail::check_read_only<written_fields_per_reg_t>();
 
-        using all_fields_per_reg_t = boost::mp11::mp_transform<
-            detail::all_fields_t,
-            boost::mp11::mp_transform<boost::mp11::mp_list,
-                                      typename Spec::value_t>>;
+    using all_fields_per_reg_t = boost::mp11::mp_transform<
+        detail::all_fields_t,
+        boost::mp11::mp_transform<boost::mp11::mp_list,
+                                  typename Spec::value_t>>;
 
-        using unwritten_fields_per_reg_t =
-            boost::mp11::mp_transform<boost::mp11::mp_set_difference,
-                                      all_fields_per_reg_t,
-                                      written_fields_per_reg_t>;
+    using unwritten_fields_per_reg_t =
+        boost::mp11::mp_transform<boost::mp11::mp_set_difference,
+                                  all_fields_per_reg_t,
+                                  written_fields_per_reg_t>;
 
-        using field_masks_t =
-            boost::mp11::mp_transform<detail::compute_mask_t,
-                                      typename Spec::value_t,
-                                      written_fields_per_reg_t>;
+    using field_masks_t = boost::mp11::mp_transform<detail::compute_mask_t,
+                                                    typename Spec::value_t,
+                                                    written_fields_per_reg_t>;
 
-        using identity_masks_t =
-            boost::mp11::mp_transform<detail::compute_id_mask_t,
-                                      typename Spec::value_t,
-                                      unwritten_fields_per_reg_t>;
+    using identity_masks_t =
+        boost::mp11::mp_transform<detail::compute_id_mask_t,
+                                  typename Spec::value_t,
+                                  unwritten_fields_per_reg_t>;
 
-        using identity_values_t =
-            boost::mp11::mp_transform<detail::compute_id_value_t,
-                                      typename Spec::value_t,
-                                      unwritten_fields_per_reg_t>;
+    using identity_values_t =
+        boost::mp11::mp_transform<detail::compute_id_value_t,
+                                  typename Spec::value_t,
+                                  unwritten_fields_per_reg_t>;
 
-        using reg_identity_masks_t =
-            boost::mp11::mp_transform<detail::compute_reg_id_mask_t,
-                                      typename Spec::value_t>;
-        using reg_identity_values_t =
-            boost::mp11::mp_transform<detail::compute_reg_id_value_t,
-                                      typename Spec::value_t>;
+    using reg_identity_masks_t =
+        boost::mp11::mp_transform<detail::compute_reg_id_mask_t,
+                                  typename Spec::value_t>;
+    using reg_identity_values_t =
+        boost::mp11::mp_transform<detail::compute_reg_id_value_t,
+                                  typename Spec::value_t>;
 
-        return stdx::transform(
-                   []<typename R, typename Mask, typename IdMask,
-                      typename IdValue, typename RegIdMask,
-                      typename RegIdValue>(R const &r, Mask, IdMask, IdValue,
-                                           RegIdMask, RegIdValue) {
-                       return detail::write<
-                           R, typename Spec::bus_t, Mask::value,
-                           (IdMask::value | RegIdMask::value),
-                           (IdValue::value | RegIdValue::value)>(r.value);
-                   },
-                   s.value, field_masks_t{}, identity_masks_t{},
-                   identity_values_t{}, reg_identity_masks_t{},
-                   reg_identity_values_t{})
-            .apply([]<typename... Ws>(Ws &&...ws) {
-                return async::when_all(std::forward<Ws>(ws)...);
-            });
-    }
+    return stdx::transform(
+               []<typename R, typename Mask, typename IdMask, typename IdValue,
+                  typename RegIdMask, typename RegIdValue>(
+                   R const &r, Mask, IdMask, IdValue, RegIdMask, RegIdValue) {
+                   return detail::write<R, typename Spec::bus_t, Mask::value,
+                                        (IdMask::value | RegIdMask::value),
+                                        (IdValue::value | RegIdValue::value)>(
+                       r.value);
+               },
+               s.value, field_masks_t{}, identity_masks_t{},
+               identity_values_t{}, reg_identity_masks_t{},
+               reg_identity_values_t{})
+        .apply([]<typename... Ws>(Ws &&...ws) {
+            return async::when_all(std::forward<Ws>(ws)...);
+        });
+}
 
+namespace _write {
+struct pipeable {
   private:
     template <async::sender S>
-    friend constexpr auto operator|(S &&s, write_t self) -> async::sender auto {
+    friend constexpr auto operator|(S &&s, pipeable) -> async::sender auto {
         return std::forward<S>(s) |
                async::let_value([=]<typename Spec>(Spec &&spec) {
-                   return self(std::forward<Spec>(spec));
+                   return write(std::forward<Spec>(spec));
                });
     }
-} write{};
+};
+} // namespace _write
+
+constexpr auto write() -> _write::pipeable { return {}; }
+
+namespace _sync_write {
+template <typename Behavior, async::sender S> [[nodiscard]] auto wait(S &&s) {
+    static_assert(async::trivially_sync_waitable<S> or
+                      std::is_same_v<Behavior, blocking>,
+                  "sync_write() would block: if you really want this, use "
+                  "sync_write<blocking>()");
+    return std::forward<S>(s) | async::sync_wait();
+}
+
+template <typename Behavior> struct pipeable {
+  private:
+    template <async::sender S>
+    friend constexpr auto operator|(S &&s, pipeable) -> decltype(auto) {
+        return wait<Behavior>(std::forward<S>(s) | write());
+    }
+};
+} // namespace _sync_write
+
+template <typename Behavior = non_blocking, typename T>
+[[nodiscard]] auto sync_write(T const &t) {
+    return _sync_write::wait<Behavior>(write(t));
+}
+
+template <typename Behavior = non_blocking>
+[[nodiscard]] auto sync_write() -> _sync_write::pipeable<Behavior> {
+    return {};
+}
 } // namespace groov

--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -13,7 +13,9 @@ add_fail_tests(
     path_too_long
     read_ambiguous_path
     read_invalid_path
-    read_only_field_without_identity)
+    read_only_field_without_identity
+    sync_read_nontrivial
+    sync_write_nontrivial)
 
 function(add_formatted_error_tests)
     add_fail_tests(write_read_only_field)

--- a/test/fail/read_invalid_path.cpp
+++ b/test/fail/read_invalid_path.cpp
@@ -5,7 +5,6 @@
 
 #include <async/concepts.hpp>
 #include <async/just.hpp>
-#include <async/sync_wait.hpp>
 
 #include <cstdint>
 
@@ -32,10 +31,6 @@ std::uint32_t data1{};
 using R1 = groov::reg<"reg1", std::uint32_t, &data1, groov::w::replace, F0>;
 
 using G = groov::group<"group", bus, R0, R1>;
-
-template <typename T> auto sync_read(T const &t) {
-    return get<0>(*(groov::read(t) | async::sync_wait()));
-}
 } // namespace
 
 auto main() -> int {

--- a/test/fail/sync_read_nontrivial.cpp
+++ b/test/fail/sync_read_nontrivial.cpp
@@ -1,14 +1,14 @@
 #include <groov/config.hpp>
 #include <groov/path.hpp>
 #include <groov/read.hpp>
-#include <groov/read_spec.hpp>
 
 #include <async/concepts.hpp>
-#include <async/just.hpp>
+#include <async/schedulers/thread_scheduler.hpp>
+#include <async/then.hpp>
 
 #include <cstdint>
 
-// EXPECT: Ambiguous path passed to write_spec
+// EXPECT: sync_read\(\) would block
 
 namespace {
 struct bus {
@@ -16,26 +16,22 @@ struct bus {
         using is_sender = void;
     };
     template <auto> static auto read(auto...) -> async::sender auto {
-        return async::just(42);
+        return async::thread_scheduler{}.schedule() |
+               async::then([] { return 42; });
     }
     template <auto...> static auto write(auto...) -> async::sender auto {
         return dummy_sender{};
     }
 };
 
-using F0 = groov::field<"field0", std::uint8_t, 0, 0>;
-
 std::uint32_t data0{};
-using R0 = groov::reg<"reg0", std::uint32_t, &data0, groov::w::replace, F0>;
-std::uint32_t data1{};
-using R1 = groov::reg<"reg1", std::uint32_t, &data1, groov::w::replace, F0>;
+using R0 = groov::reg<"reg0", std::uint32_t, &data0, groov::w::replace>;
 
-using G = groov::group<"group", bus, R0, R1>;
+using G = groov::group<"group", bus, R0>;
 } // namespace
 
 auto main() -> int {
     using namespace groov::literals;
     constexpr auto grp = G{};
-    auto const result = sync_read(grp("reg0.field0"_f, "reg1.field0"_f));
-    return result["field0"_f];
+    [[maybe_unused]] auto const result = sync_read(grp / "reg0"_r);
 }

--- a/test/fail/sync_write_nontrivial.cpp
+++ b/test/fail/sync_write_nontrivial.cpp
@@ -1,0 +1,38 @@
+#include <groov/config.hpp>
+#include <groov/path.hpp>
+#include <groov/value_path.hpp>
+#include <groov/write.hpp>
+#include <groov/write_spec.hpp>
+
+#include <async/concepts.hpp>
+#include <async/schedulers/thread_scheduler.hpp>
+#include <async/then.hpp>
+
+#include <cstdint>
+
+// EXPECT: sync_write\(\) would block
+
+namespace {
+struct bus {
+    struct dummy_sender {
+        using is_sender = void;
+    };
+    template <auto> static auto read(auto...) -> async::sender auto {
+        return dummy_sender{};
+    }
+    template <auto...> static auto write(auto...) -> async::sender auto {
+        return async::thread_scheduler{}.schedule();
+    }
+};
+
+std::uint32_t data0{};
+using R0 = groov::reg<"reg0", std::uint32_t, &data0, groov::w::replace>;
+
+using G = groov::group<"group", bus, R0>;
+} // namespace
+
+auto main() -> int {
+    using namespace groov::literals;
+    constexpr auto grp = G{};
+    [[maybe_unused]] auto const result = sync_write(grp("reg0"_r = 0));
+}

--- a/test/fail/write_read_only_field.cpp
+++ b/test/fail/write_read_only_field.cpp
@@ -7,7 +7,6 @@
 
 #include <async/concepts.hpp>
 #include <async/just_result_of.hpp>
-#include <async/sync_wait.hpp>
 
 #include <cstdint>
 
@@ -34,13 +33,9 @@ using F = groov::field<"field", std::uint8_t, 0, 0,
 std::uint32_t data{};
 using R = groov::reg<"reg", std::uint32_t, &data, groov::w::replace, F>;
 using G = groov::group<"group", bus, R>;
-
-template <typename T> auto sync_write(T const &t) {
-    return groov::write(t) | async::sync_wait();
-}
 } // namespace
 
 auto main() -> int {
     using namespace groov::literals;
-    sync_write(G{}("reg.field"_f = 1));
+    [[maybe_unused]] auto x = sync_write(G{}("reg.field"_f = 1));
 }

--- a/test/read.cpp
+++ b/test/read.cpp
@@ -45,13 +45,17 @@ using R1 =
 
 using G = groov::group<"group", bus, R0, R1>;
 constexpr auto grp = G{};
-
-template <typename T> auto sync_read(T const &t) {
-    return get<0>(*(groov::read(t) | async::sync_wait()));
-}
 } // namespace
 
 TEST_CASE("read a register", "[read]") {
+    using namespace groov::literals;
+    data0 = 0xa5a5'a5a5u;
+    auto s = read(grp / "reg0"_r);
+    auto r = get<0>(*(s | async::sync_wait()));
+    CHECK(r["reg0"_r] == data0);
+}
+
+TEST_CASE("sync_read a register", "[read]") {
     using namespace groov::literals;
     data0 = 0xa5a5'a5a5u;
     auto r = sync_read(grp / "reg0"_r);
@@ -172,8 +176,15 @@ TEST_CASE("read mask is passed to bus", "[read]") {
 TEST_CASE("read is pipeable", "[read]") {
     using namespace groov::literals;
     data0 = 0xa5a5'a5a5u;
-    auto r = async::just(grp / "reg0"_r) | groov::read | async::sync_wait();
+    auto r = async::just(grp / "reg0"_r) | groov::read() | async::sync_wait();
     CHECK(get<0>(*r)["reg0"_r] == data0);
+}
+
+TEST_CASE("sync_read is pipeable", "[read]") {
+    using namespace groov::literals;
+    data0 = 0xa5a5'a5a5u;
+    auto r = async::just(grp / "reg0"_r) | groov::sync_read();
+    CHECK(r["reg0"_r] == data0);
 }
 
 namespace {

--- a/test/write_functions.cpp
+++ b/test/write_functions.cpp
@@ -37,10 +37,6 @@ struct bus {
     }
 };
 
-template <typename T> auto sync_write(T const &t) {
-    return groov::write(t) | async::sync_wait();
-}
-
 struct custom_field_func {
     struct id_spec {
         template <auto Mask>
@@ -69,7 +65,7 @@ TEST_CASE("write a register with a custom write function field",
     using namespace groov::literals;
     bus::num_writes = 0;
     data = 0b0100'0000u;
-    sync_write(grp("reg.field"_f = 1));
+    CHECK(sync_write(grp("reg.field"_f = 1)));
     CHECK(bus::num_writes == 1);
     CHECK(data == 0b0110'0010);
 }

--- a/usage_test/main.cpp
+++ b/usage_test/main.cpp
@@ -36,12 +36,12 @@ auto main() -> int {
     using namespace groov::literals;
     data = 0xa5u;
     async::just(grp / "reg"_r) //
-        | groov::read          //
+        | groov::read()        //
         | async::then([](auto spec) {
               spec["reg"_r] ^= 0xff;
               return spec;
-          })           //
-        | groov::write //
+          })             //
+        | groov::write() //
         | async::sync_wait();
     assert(data == 0x5au);
 }


### PR DESCRIPTION
Problem:
- Reading and writing registers with an MMIO bus is a synchronous operation that won't fail; there isn't an ergonomic way provided to do this simple thing.

Solution:
- Add `sync_read` and `sync_write`. When passed a sender that completes synchronously, they call `sync_wait` and assume success.

Note:
- This change also changes `read` and `write` from being function objects to functions. This means that ADL works, and makes them analogous to `sync_read` and `sync_write`. It also makes them the same kind of things as everything else in the S&R library.