### PR TITLE
:sparkles: Make `read` and `write` adaptor-pipeable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 add_versioned_package("gh:boostorg/mp11#boost-1.83.0")
 add_versioned_package("gh:intel/cpp-baremetal-concurrency#9d6573a")
 add_versioned_package("gh:intel/cpp-std-extensions#73e1d48")
-add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#8d87a4b")
+add_versioned_package("gh:intel/cpp-baremetal-senders-and-receivers#3bc2c03")
 
 find_package(Python3 COMPONENTS Interpreter)
 

--- a/include/groov/read.hpp
+++ b/include/groov/read.hpp
@@ -5,6 +5,7 @@
 #include <groov/read_spec.hpp>
 #include <groov/write_spec.hpp>
 
+#include <async/compose.hpp>
 #include <async/concepts.hpp>
 #include <async/let_value.hpp>
 #include <async/sync_wait.hpp>
@@ -58,7 +59,7 @@ struct pipeable {
 };
 } // namespace _read
 
-constexpr auto read() -> _read::pipeable { return {}; }
+constexpr auto read() { return async::compose(_read::pipeable{}); }
 
 namespace _sync_read {
 template <typename Behavior, async::sender S> [[nodiscard]] auto wait(S &&s) {

--- a/include/groov/write.hpp
+++ b/include/groov/write.hpp
@@ -133,7 +133,7 @@ struct pipeable {
 };
 } // namespace _write
 
-constexpr auto write() -> _write::pipeable { return {}; }
+constexpr auto write() { return async::compose(_write::pipeable{}); }
 
 namespace _sync_write {
 template <typename Behavior, async::sender S> [[nodiscard]] auto wait(S &&s) {

--- a/test/read.cpp
+++ b/test/read.cpp
@@ -6,6 +6,7 @@
 #include <async/just.hpp>
 #include <async/just_result_of.hpp>
 #include <async/sync_wait.hpp>
+#include <async/then.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -185,6 +186,14 @@ TEST_CASE("sync_read is pipeable", "[read]") {
     data0 = 0xa5a5'a5a5u;
     auto r = async::just(grp / "reg0"_r) | groov::sync_read();
     CHECK(r["reg0"_r] == data0);
+}
+
+TEST_CASE("read is adaptor-pipeable", "[read]") {
+    using namespace groov::literals;
+    data0 = 0xa5a5'a5a5u;
+    auto s = groov::read() | async::then([](auto spec) { return spec; });
+    auto r = async::just(grp / "reg0"_r) | s | async::sync_wait();
+    CHECK(get<0>(*r)["reg0"_r] == data0);
 }
 
 namespace {

--- a/test/write.cpp
+++ b/test/write.cpp
@@ -55,12 +55,14 @@ constexpr auto grp = G{};
 
 TEST_CASE("write a register", "[write]") {
     using namespace groov::literals;
+    data0 = 0;
     CHECK(groov::write(grp("reg0"_r = 0xa5a5'a5a5u)) | async::sync_wait());
     CHECK(data0 == 0xa5a5'a5a5u);
 }
 
 TEST_CASE("sync_write a register", "[write]") {
     using namespace groov::literals;
+    data0 = 0;
     CHECK(sync_write(grp("reg0"_r = 0xa5a5'a5a5u)));
     CHECK(data0 == 0xa5a5'a5a5u);
 }
@@ -112,6 +114,7 @@ TEST_CASE("write mask is passed to bus", "[write]") {
 
 TEST_CASE("write is pipeable", "[write]") {
     using namespace groov::literals;
+    data0 = 0;
     auto r = async::just(grp("reg0"_r = 0xa5a5'a5a5u)) | groov::write() |
              async::sync_wait();
     CHECK(r);
@@ -120,7 +123,17 @@ TEST_CASE("write is pipeable", "[write]") {
 
 TEST_CASE("sync_write is pipeable", "[write]") {
     using namespace groov::literals;
+    data0 = 0;
     auto r = async::just(grp("reg0"_r = 0xa5a5'a5a5u)) | groov::sync_write();
+    CHECK(r);
+    CHECK(data0 == 0xa5a5'a5a5u);
+}
+
+TEST_CASE("write is adaptor-pipeable", "[write]") {
+    using namespace groov::literals;
+    data0 = 0;
+    auto s = groov::write() | async::then([] {});
+    auto r = async::just(grp("reg0"_r = 0xa5a5'a5a5u)) | s | async::sync_wait();
     CHECK(r);
     CHECK(data0 == 0xa5a5'a5a5u);
 }


### PR DESCRIPTION
Problem:
- `read` and `write` are sender adaptors, but they are not usable in adaptor pipelines without a sender on the left hand side.

Solution:
- Wrap `read` and `write` adaptors in `async::compose` where necessary so that they are composable.