### PR TITLE
:children_crossing: Protect against accidentally indexing a write_spe…

### DIFF
--- a/include/groov/write_spec.hpp
+++ b/include/groov/write_spec.hpp
@@ -140,6 +140,14 @@ struct write_spec : Group {
         return F::extract(r.value);
     }
 
+    template <std::size_t N>
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+    constexpr auto operator[](char const (&)[N]) const {
+        static_assert(stdx::always_false_v<write_spec>,
+                      "Trying to index into a write_spec with a string "
+                      "literal: did you forget to use the UDL?");
+    }
+
     // NOLINTNEXTLINE(google-explicit-constructor)
     constexpr operator extract_type() const
         requires(not std::is_same_v<extract_type, detail::no_extract_type>)

--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -15,7 +15,8 @@ add_fail_tests(
     read_invalid_path
     read_only_field_without_identity
     sync_read_nontrivial
-    sync_write_nontrivial)
+    sync_write_nontrivial
+    write_spec_literal_index)
 
 function(add_formatted_error_tests)
     add_fail_tests(write_read_only_field)

--- a/test/fail/write_spec_literal_index.cpp
+++ b/test/fail/write_spec_literal_index.cpp
@@ -1,0 +1,38 @@
+#include <groov/config.hpp>
+#include <groov/path.hpp>
+#include <groov/resolve.hpp>
+#include <groov/value_path.hpp>
+#include <groov/write_spec.hpp>
+
+#include <async/concepts.hpp>
+
+// EXPECT: Trying to index into a write_spec with a string literal
+
+namespace {
+struct bus {
+    struct sender {
+        using is_sender = void;
+    };
+
+    template <auto> static auto read(auto...) -> async::sender auto {
+        return sender{};
+    }
+    template <auto...> static auto write(auto...) -> async::sender auto {
+        return sender{};
+    }
+};
+
+using F = groov::field<"field", std::uint8_t, 0, 0>;
+
+std::uint32_t data0{};
+using R = groov::reg<"reg", std::uint32_t, &data0, groov::w::replace, F>;
+
+using G = groov::group<"group", bus, R>;
+constexpr auto grp = G{};
+} // namespace
+
+auto main() -> int {
+    using namespace groov::literals;
+    auto const spec = grp("reg"_r = 5);
+    auto x = spec["reg"];
+}


### PR DESCRIPTION
…c with literal

Problem:

When we write:
```cpp
auto const spec = grp("reg0"_r = 5);
auto const value = spec["reg0"];    // oops, forgot the _r UDL
```

What actually happens is not obvious: `spec` can implicitly convert to its integral type (typically `std::uint32_t`) and the resulting code is equivalent to:

```cpp
auto const spec = grp("reg0"_r = 5);
auto const value = "reg0"[static_cast<std::uint32_t>(spec)];    // accidentally indexing into a literal!
```

Which is probably an out-of-bounds access.

Solution:
- Provide an overload for `write_spec::operator[]` that takes a string literal and `static_assert`​s that you probably meant to use the UDL.

Note:
- We can't automatically convert a string literal to a path, because once we have it in the `operator[]`, it's no longer `constexpr`.

Closes: #95 