### PR TITLE
:art: Remove `[[nodiscard]]` for non-blocking `sync_write`

### DIFF
--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -16,6 +16,7 @@ add_fail_tests(
     read_only_field_without_identity
     sync_read_nontrivial
     sync_write_nontrivial
+    sync_write_nontrivial_nodiscard
     write_spec_literal_index)
 
 function(add_formatted_error_tests)

--- a/test/fail/sync_write_nontrivial_nodiscard.cpp
+++ b/test/fail/sync_write_nontrivial_nodiscard.cpp
@@ -1,0 +1,38 @@
+#include <groov/config.hpp>
+#include <groov/path.hpp>
+#include <groov/value_path.hpp>
+#include <groov/write.hpp>
+#include <groov/write_spec.hpp>
+
+#include <async/concepts.hpp>
+#include <async/schedulers/thread_scheduler.hpp>
+#include <async/then.hpp>
+
+#include <cstdint>
+
+// EXPECT: ignoring return
+
+namespace {
+struct bus {
+    struct dummy_sender {
+        using is_sender = void;
+    };
+    template <auto> static auto read(auto...) -> async::sender auto {
+        return dummy_sender{};
+    }
+    template <auto...> static auto write(auto...) -> async::sender auto {
+        return async::thread_scheduler{}.schedule();
+    }
+};
+
+std::uint32_t data0{};
+using R0 = groov::reg<"reg0", std::uint32_t, &data0, groov::w::replace>;
+
+using G = groov::group<"group", bus, R0>;
+} // namespace
+
+auto main() -> int {
+    using namespace groov::literals;
+    constexpr auto grp = G{};
+    sync_write<groov::blocking>(grp("reg0"_r = 0));
+}

--- a/test/write.cpp
+++ b/test/write.cpp
@@ -67,6 +67,13 @@ TEST_CASE("sync_write a register", "[write]") {
     CHECK(data0 == 0xa5a5'a5a5u);
 }
 
+TEST_CASE("non-blocking sync_write is not nodiscard", "[write]") {
+    using namespace groov::literals;
+    data0 = 0;
+    sync_write(grp("reg0"_r = 0xa5a5'a5a5u));
+    CHECK(data0 == 0xa5a5'a5a5u);
+}
+
 TEST_CASE("write a field", "[write]") {
     using namespace groov::literals;
     data0 = 0b1'1010'1u;
@@ -108,7 +115,7 @@ TEST_CASE("write multiple fields to each of multiple registers", "[write]") {
 
 TEST_CASE("write mask is passed to bus", "[write]") {
     using namespace groov::literals;
-    [[maybe_unused]] auto r = sync_write(grp("reg0.field1"_f = 5));
+    CHECK(sync_write(grp("reg0.field1"_f = 5)));
     CHECK(bus::last_mask == 0b1111'0u);
 }
 


### PR DESCRIPTION
Problem:
- Most of the time when we call `sync_write`, it can't fail, and it returns a `optional<tuple<>>`. It's annoying to handle this because of `[[nodiscard]]`.

Solution:
- Remove `[[nodiscard]]` attribute on `sync_write`.
- When forcing a `sync_write` that blocks, return a `[[nodiscard]]` type that wraps the `optional<tuple<...>>`.