### PR TITLE
:sparkles: Add enable/disable write functionality

### DIFF
--- a/include/groov/config.hpp
+++ b/include/groov/config.hpp
@@ -292,4 +292,9 @@ using all_fields_t = boost::mp11::mp_back<boost::mp11::mp_iterate<
 
 struct blocking;
 struct non_blocking;
+
+struct enable_t {};
+constexpr auto enable = enable_t{};
+struct disable_t {};
+constexpr auto disable = disable_t{};
 } // namespace groov

--- a/test/write.cpp
+++ b/test/write.cpp
@@ -251,9 +251,34 @@ using G_enum = groov::group<"group", bus, R_enum>;
 constexpr auto grp_enum = G_enum{};
 } // namespace
 
-TEST_CASE("write an enum field", "[read]") {
+TEST_CASE("write an enum field", "[write]") {
     using namespace groov::literals;
     data_enum = 0u;
     CHECK(sync_write(grp_enum("reg.field"_f = E::C)));
     CHECK(data_enum == 0b10u);
+}
+
+namespace {
+enum struct EnableTest : std::uint8_t { DISABLE = 0, ENABLE = 1 };
+using F_enum_enable = groov::field<"field", EnableTest, 0, 0>;
+
+using R_enum_enable = groov::reg<"reg", std::uint32_t, &data_enum,
+                                 groov::w::replace, F_enum_enable>;
+
+using G_enum_enable = groov::group<"group", bus, R_enum_enable>;
+constexpr auto grp_enum_enable = G_enum_enable{};
+} // namespace
+
+TEST_CASE("enable an enum field", "[write]") {
+    using namespace groov::literals;
+    data_enum = 0u;
+    CHECK(sync_write(grp_enum_enable("reg.field"_f = groov::enable)));
+    CHECK(data_enum == 0b1u);
+}
+
+TEST_CASE("disable an enum field", "[write]") {
+    using namespace groov::literals;
+    data_enum = 1u;
+    CHECK(sync_write(grp_enum_enable("reg.field"_f = groov::disable)));
+    CHECK(data_enum == 0u);
 }


### PR DESCRIPTION
Problem:
- It's not always generically easy to enable/disable a field.

Solution:
- Add `enable` and `disable` as values that can occur on the RHS when setting a value to write. They are valid for enum fields that contain `ENABLE` and `DISABLE` values respectively.