### PR TITLE
:art: Allow a register to have an address obtained from a function

### DIFF
--- a/include/groov/read.hpp
+++ b/include/groov/read.hpp
@@ -23,7 +23,7 @@ namespace detail {
 template <typename Register, typename Group, typename Mask>
 auto read() -> async::sender auto {
     using bus_t = typename Group::bus_t;
-    return bus_t::template read<Mask::value>(Register::address);
+    return bus_t::template read<Mask::value>(get_address<Register>());
 }
 } // namespace detail
 

--- a/include/groov/write.hpp
+++ b/include/groov/write.hpp
@@ -18,15 +18,13 @@
 #include <type_traits>
 #include <utility>
 
-template <typename...> struct undef;
-template <auto...> struct undef_v;
-
 namespace groov {
 namespace detail {
 template <typename Register, typename Bus, auto Mask, auto IdMask, auto IdValue,
           typename V>
 auto write(V value) -> async::sender auto {
-    return Bus::template write<Mask, IdMask, IdValue>(Register::address, value);
+    return Bus::template write<Mask, IdMask, IdValue>(get_address<Register>(),
+                                                      value);
 }
 
 template <typename Reg, typename ObjList>

--- a/test/write.cpp
+++ b/test/write.cpp
@@ -312,3 +312,16 @@ TEST_CASE("disable with field_proxy", "[write]") {
     CHECK(r);
     CHECK(data_enum == 0u);
 }
+
+namespace {
+std::uint32_t data_fn{};
+}
+
+TEST_CASE("write a register with address function", "[write]") {
+    using R = groov::reg<"reg", std::uint32_t, [] { return &data_fn; }>;
+    constexpr auto g = groov::group<"group", bus, R>{};
+
+    using namespace groov::literals;
+    CHECK(sync_write(g("reg"_r = 0xa5a5'a5a5u)));
+    CHECK(data_fn == 0xa5a5'a5a5u);
+}


### PR DESCRIPTION
Problem:
- Some registers' addresses are set at initialization time rather than at compile time.

Solution:
- Allow a register's address to be obtained from a function.