### PR TITLE
:sparkles: Add passthrough capability to `write`

### DIFF
--- a/include/groov/write_spec.hpp
+++ b/include/groov/write_spec.hpp
@@ -171,6 +171,7 @@ template <typename R, typename F> struct field_proxy {
 
 template <typename Group, typename Paths, typename Value>
 struct write_spec : Group {
+    using is_write_spec = void;
     using paths_t = Paths;
     using value_t = Value;
     [[no_unique_address]] value_t value;

--- a/test/write.cpp
+++ b/test/write.cpp
@@ -61,10 +61,31 @@ TEST_CASE("write a register", "[write]") {
     CHECK(data0 == 0xa5a5'a5a5u);
 }
 
+TEST_CASE("write with passthrough", "[write]") {
+    using namespace groov::literals;
+    data0 = 0;
+    auto value =
+        groov::write(grp("reg0"_r = 0xa5a5'a5a5u), 42, 17) | async::sync_wait();
+    CHECK(value);
+    CHECK(get<0>(*value) == 42);
+    CHECK(get<1>(*value) == 17);
+    CHECK(data0 == 0xa5a5'a5a5u);
+}
+
 TEST_CASE("sync_write a register", "[write]") {
     using namespace groov::literals;
     data0 = 0;
     CHECK(sync_write(grp("reg0"_r = 0xa5a5'a5a5u)));
+    CHECK(data0 == 0xa5a5'a5a5u);
+}
+
+TEST_CASE("sync_write with passthrough", "[write]") {
+    using namespace groov::literals;
+    data0 = 0;
+    auto value = sync_write(grp("reg0"_r = 0xa5a5'a5a5u), 42, 17);
+    CHECK(value);
+    CHECK(get<0>(*value) == 42);
+    CHECK(get<1>(*value) == 17);
     CHECK(data0 == 0xa5a5'a5a5u);
 }
 
@@ -143,11 +164,33 @@ TEST_CASE("write is pipeable", "[write]") {
     CHECK(data0 == 0xa5a5'a5a5u);
 }
 
+TEST_CASE("write is pipeable with passthrough", "[write]") {
+    using namespace groov::literals;
+    data0 = 0;
+    auto r = async::just(grp("reg0"_r = 0xa5a5'a5a5u)) | groov::write(42, 17) |
+             async::sync_wait();
+    CHECK(r);
+    CHECK(get<0>(*r) == 42);
+    CHECK(get<1>(*r) == 17);
+    CHECK(data0 == 0xa5a5'a5a5u);
+}
+
 TEST_CASE("sync_write is pipeable", "[write]") {
     using namespace groov::literals;
     data0 = 0;
     auto r = async::just(grp("reg0"_r = 0xa5a5'a5a5u)) | groov::sync_write();
     CHECK(r);
+    CHECK(data0 == 0xa5a5'a5a5u);
+}
+
+TEST_CASE("sync_write is pipeable with passthrough", "[write]") {
+    using namespace groov::literals;
+    data0 = 0;
+    auto r =
+        async::just(grp("reg0"_r = 0xa5a5'a5a5u)) | groov::sync_write(42, 17);
+    CHECK(r);
+    CHECK(get<0>(*r) == 42);
+    CHECK(get<1>(*r) == 17);
     CHECK(data0 == 0xa5a5'a5a5u);
 }
 


### PR DESCRIPTION
Problem:

- A common pattern is: read a register, use the value read, and write back to clear a flag. There are a couple of ways to achieve this with `let_value` and/or `when_all`, but they are not obvious. The "easy" pattern people come up with is something like this, squirreling away the value in global data:

```cpp
std::uint32_t stored_value{};

auto handle_reg() {
  auto s = read()
         | then([] (auto spec) {
                  stored_value = spec["value"_f];
                  spec["flag"_f] = groov::clear;
                  return spec;
                })
         | write()
         | then([] {
                   // use stored_value
                });
}
```

- This is not desirable because of the issues around accessing and ensuring correctness of global data.

Solution:

- Allow `write` to pass through values. Now the above looks like:

```cpp
auto handle_reg() {
  auto s = read()
         | then_split([] (auto spec) {
                        spec["flag"_f] = groov::clear;
                        return spec;
                      },
                      [] (auto spec) {
                        return spec["value"_f];
                      })
         | write()
         | then([] (std::uint32_t value) {
                   // use value
                });
}
```