### PR TITLE
:bug: Fix `const` path assignment

### DIFF
--- a/include/groov/path.hpp
+++ b/include/groov/path.hpp
@@ -21,7 +21,7 @@ template <stdx::ct_string... Parts> struct path {
 
     template <typename T>
     // NOLINTNEXTLINE(misc-unconventional-assign-operator)
-    constexpr auto operator=(T const &value) {
+    constexpr auto operator=(T const &value) const {
         return (*this)(value);
     }
 

--- a/test/value_path.cpp
+++ b/test/value_path.cpp
@@ -13,6 +13,15 @@ TEST_CASE("path with value (operator=)", "[value_path]") {
     STATIC_REQUIRE(v.value == 5);
 }
 
+TEST_CASE("const path with value (operator=)", "[value_path]") {
+    using namespace groov::literals;
+    constexpr auto p = "reg"_r / "field"_f;
+    constexpr auto v = p = 5;
+    STATIC_REQUIRE(std::is_same_v<groov::get_path_t<decltype(v)>,
+                                  decltype("reg.field"_f)>);
+    STATIC_REQUIRE(v.value == 5);
+}
+
 TEST_CASE("path with value (operator())", "[value_path]") {
     using namespace groov::literals;
     constexpr auto v = "reg"_r(5);


### PR DESCRIPTION
Problem:
- `operator=` on `path` is not assignment but a small DSL. However it is not marked `const`, which inhibits having `constexpr` paths in order to use them with values later.

Solution:
- Mark `path::operator=` `const`.