### PR TITLE
:rotating_light: Fix warnings arising from -Wnrvo

### DIFF
--- a/include/groov/value_path.hpp
+++ b/include/groov/value_path.hpp
@@ -45,8 +45,8 @@ template <pathlike Path, typename Value> struct value_path : Path {
             }
         } else {
             using leftover_t = resolve_t<Path, P>;
-            auto const leftover_path = groov::resolve(Path{}, p);
             if constexpr (pathlike<leftover_t>) {
+                auto const leftover_path = groov::resolve(Path{}, p);
                 if constexpr (std::empty(leftover_path) and
                               not stdx::is_specialization_of_v<value_t,
                                                                stdx::tuple>) {
@@ -55,7 +55,7 @@ template <pathlike Path, typename Value> struct value_path : Path {
                     return value_path<leftover_t, Value>{{}, value};
                 }
             } else {
-                return leftover_path;
+                return groov::resolve(Path{}, p);
             }
         }
     }

--- a/include/groov/write_spec.hpp
+++ b/include/groov/write_spec.hpp
@@ -254,19 +254,21 @@ constexpr auto to_write_spec(read_spec<Group, Paths>, Ps const &...ps) {
     using register_data_t =
         boost::mp11::mp_apply<stdx::tuple, register_values_t>;
 
-    auto w = write_spec<Group, Paths, register_data_t>{};
-    [[maybe_unused]] constexpr auto insert =
-        []<valued_pathlike P>(P const &p, [[maybe_unused]] auto &values) {
-            using matches =
-                boost::mp11::mp_copy_if_q<register_values_t, resolves_q<P>>;
-            using R = boost::mp11::mp_first<matches>;
-            auto &dest_reg = stdx::get<R>(values);
-            using F = resolve_t<R, typename P::path_t>;
+    return [&]() -> write_spec<Group, Paths, register_data_t> {
+        auto w = write_spec<Group, Paths, register_data_t>{};
+        [[maybe_unused]] constexpr auto insert =
+            []<valued_pathlike P>(P const &p, [[maybe_unused]] auto &values) {
+                using matches =
+                    boost::mp11::mp_copy_if_q<register_values_t, resolves_q<P>>;
+                using R = boost::mp11::mp_first<matches>;
+                auto &dest_reg = stdx::get<R>(values);
+                using F = resolve_t<R, typename P::path_t>;
 
-            F::insert(dest_reg.value, detail::convert_value<F>(p.value));
-        };
-    (insert(ps, w.value), ...);
-    return w;
+                F::insert(dest_reg.value, detail::convert_value<F>(p.value));
+            };
+        (insert(ps, w.value), ...);
+        return w;
+    }();
 }
 
 template <typename G, valued_pathlike... Ps>


### PR DESCRIPTION
Problem:
- `groov` is not warning free with respect to `-Wnrvo`.

Solution:
- Add a couple of trailing return types to fix warnings.