### PR TITLE
:bug: Update mmio_bus read/write with regname

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install Mermaid
         run: |
-          npm install -g @mermaid-js/mermaid-cli@11.4.2
+          npm install -g @mermaid-js/mermaid-cli@11.12.0
           npx puppeteer browsers install chrome-headless-shell
 
       - name: Install asciidoctor

--- a/include/groov/mmio_bus.hpp
+++ b/include/groov/mmio_bus.hpp
@@ -7,6 +7,8 @@
 #include <async/just_result_of.hpp>
 #include <async/then.hpp>
 
+#include <stdx/ct_string.hpp>
+
 #include <boost/mp11/algorithm.hpp>
 #include <boost/mp11/integral.hpp>
 #include <boost/mp11/list.hpp>
@@ -100,7 +102,8 @@ struct cpp_mem_iface {
 template <typename HardwareInterface = cpp_mem_iface> struct mmio_bus {
     using iface = HardwareInterface;
 
-    template <auto Mask, decltype(Mask) IdMask, decltype(Mask) IdValue>
+    template <stdx::ct_string, auto Mask, decltype(Mask) IdMask,
+              decltype(Mask) IdValue>
         requires std::unsigned_integral<decltype(Mask)>
     static auto write(auto addr, decltype(Mask) value) -> async::sender auto {
         static_assert((Mask & IdMask) == decltype(Mask){});
@@ -144,7 +147,7 @@ template <typename HardwareInterface = cpp_mem_iface> struct mmio_bus {
         }
     }
 
-    template <std::unsigned_integral auto Mask>
+    template <stdx::ct_string, std::unsigned_integral auto Mask>
     static auto read(auto addr) -> async::sender auto {
         using base_type = decltype(Mask);
         return iface::template load<base_type>(addr);

--- a/test/mmio_bus.cpp
+++ b/test/mmio_bus.cpp
@@ -46,7 +46,7 @@ TEST_CASE("subword write optimization", "[mmio_bus]") {
     iface::num_loads = {};
 
     SECTION("write the whole register") {
-        CHECK(bus::write<0xffff'ffffu, 0u, 0u>(addr32, 0xc001'd00du) |
+        CHECK(bus::write<"", 0xffff'ffffu, 0u, 0u>(addr32, 0xc001'd00du) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -55,7 +55,8 @@ TEST_CASE("subword write optimization", "[mmio_bus]") {
     }
 
     SECTION("write byte 0") {
-        CHECK(bus::write<0xffu, 0u, 0u>(addr32, 0x38u) | async::sync_wait());
+        CHECK(bus::write<"", 0xffu, 0u, 0u>(addr32, 0x38u) |
+              async::sync_wait());
 
         CHECK(iface::num_stores == 1);
         CHECK(iface::num_loads == 0);
@@ -63,7 +64,7 @@ TEST_CASE("subword write optimization", "[mmio_bus]") {
     }
 
     SECTION("write byte 1") {
-        CHECK(bus::write<0xff00u, 0u, 0u>(addr32, 0x4200u) |
+        CHECK(bus::write<"", 0xff00u, 0u, 0u>(addr32, 0x4200u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -72,7 +73,7 @@ TEST_CASE("subword write optimization", "[mmio_bus]") {
     }
 
     SECTION("write byte 2") {
-        CHECK(bus::write<0xff'0000u, 0u, 0u>(addr32, 0x55'0000u) |
+        CHECK(bus::write<"", 0xff'0000u, 0u, 0u>(addr32, 0x55'0000u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -81,7 +82,7 @@ TEST_CASE("subword write optimization", "[mmio_bus]") {
     }
 
     SECTION("write byte 3") {
-        CHECK(bus::write<0xff00'0000u, 0u, 0u>(addr32, 0x1300'0000u) |
+        CHECK(bus::write<"", 0xff00'0000u, 0u, 0u>(addr32, 0x1300'0000u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -90,7 +91,7 @@ TEST_CASE("subword write optimization", "[mmio_bus]") {
     }
 
     SECTION("write word at offset 0") {
-        CHECK(bus::write<0xffffu, 0u, 0u>(addr32, 0xd00du) |
+        CHECK(bus::write<"", 0xffffu, 0u, 0u>(addr32, 0xd00du) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -99,7 +100,7 @@ TEST_CASE("subword write optimization", "[mmio_bus]") {
     }
 
     SECTION("write word at offset 2") {
-        CHECK(bus::write<0xffff'0000u, 0u, 0u>(addr32, 0x6502'0000u) |
+        CHECK(bus::write<"", 0xffff'0000u, 0u, 0u>(addr32, 0x6502'0000u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -114,7 +115,7 @@ TEST_CASE("read-modify-write", "[mmio_bus]") {
     iface::num_loads = {};
 
     SECTION("write a single bit") {
-        CHECK(bus::write<0x1u, 0u, 0u>(addr32, 0u) | async::sync_wait());
+        CHECK(bus::write<"", 0x1u, 0u, 0u>(addr32, 0u) | async::sync_wait());
 
         CHECK(iface::num_stores == 1);
         CHECK(iface::num_loads == 1);
@@ -122,7 +123,7 @@ TEST_CASE("read-modify-write", "[mmio_bus]") {
     }
 
     SECTION("write a nibble") {
-        CHECK(bus::write<0xf000u, 0u, 0u>(addr32, 0x7000u) |
+        CHECK(bus::write<"", 0xf000u, 0u, 0u>(addr32, 0x7000u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -137,7 +138,7 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
     iface::num_loads = {};
 
     SECTION("write bit in byte 0") {
-        CHECK(bus::write<0x1u, 0xffff'fffeu, 0xffff'fffeu>(addr32, 0u) |
+        CHECK(bus::write<"", 0x1u, 0xffff'fffeu, 0xffff'fffeu>(addr32, 0u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -145,7 +146,8 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
         CHECK(reg32 == 0xffff'fffeu);
     }
     SECTION("write bit in byte 0 - requires subword write") {
-        CHECK(bus::write<0x1u, 0xfeu, 0xfeu>(addr32, 0u) | async::sync_wait());
+        CHECK(bus::write<"", 0x1u, 0xfeu, 0xfeu>(addr32, 0u) |
+              async::sync_wait());
 
         CHECK(iface::num_stores == 1);
         CHECK(iface::num_loads == 0);
@@ -153,7 +155,8 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
     }
 
     SECTION("write nibble in byte 1") {
-        CHECK(bus::write<0x0f00u, 0xffff'f0ffu, 0xffff'f0ffu>(addr32, 0x0300u) |
+        CHECK(bus::write<"", 0x0f00u, 0xffff'f0ffu, 0xffff'f0ffu>(addr32,
+                                                                  0x0300u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -162,7 +165,7 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
     }
 
     SECTION("write nibble in byte 1 - requires subword write") {
-        CHECK(bus::write<0x0f00u, 0xf0ffu, 0xf0ffu>(addr32, 0x0300u) |
+        CHECK(bus::write<"", 0x0f00u, 0xf0ffu, 0xf0ffu>(addr32, 0x0300u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -171,7 +174,7 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
     }
 
     SECTION("write across two bytes - requires subword write") {
-        CHECK(bus::write<0x0ff0u, 0xf00fu, 0xf00fu>(addr32, 0x0340u) |
+        CHECK(bus::write<"", 0x0ff0u, 0xf00fu, 0xf00fu>(addr32, 0x0340u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -180,8 +183,8 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
     }
 
     SECTION("write nibble in byte 2") {
-        CHECK(bus::write<0xf0'0000u, 0xff0f'ffffu, 0xff0f'ffffu>(addr32,
-                                                                 0x40'0000u) |
+        CHECK(bus::write<"", 0xf0'0000u, 0xff0f'ffffu, 0xff0f'ffffu>(
+                  addr32, 0x40'0000u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -190,7 +193,7 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
     }
 
     SECTION("write nibble in byte 3") {
-        CHECK(bus::write<0x0f00'0000u, 0xf0ff'ffffu, 0xf0ff'ffffu>(
+        CHECK(bus::write<"", 0x0f00'0000u, 0xf0ff'ffffu, 0xf0ff'ffffu>(
                   addr32, 0x1300'0000u) |
               async::sync_wait());
 
@@ -200,8 +203,8 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
     }
 
     SECTION("write across three bytes") {
-        CHECK(bus::write<0xff'ffffu, 0xff00'0000u, 0xff00'0000u>(addr32,
-                                                                 0x41'd00du) |
+        CHECK(bus::write<"", 0xff'ffffu, 0xff00'0000u, 0xff00'0000u>(
+                  addr32, 0x41'd00du) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -210,8 +213,9 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
     }
 
     SECTION("write across three bytes - check id bit write") {
-        CHECK(bus::write<0x00ff'ffffu, 0xff00'0000u, 0u>(addr32, 0x41'd00du) |
-              async::sync_wait());
+        CHECK(
+            bus::write<"", 0x00ff'ffffu, 0xff00'0000u, 0u>(addr32, 0x41'd00du) |
+            async::sync_wait());
 
         CHECK(iface::num_stores == 1);
         CHECK(iface::num_loads == 0);
@@ -219,7 +223,7 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
     }
 
     SECTION("write across three bytes - start at byte 1") {
-        CHECK(bus::write<0xffff'ff00u, 0x0000'00ffu, 0x0000'00ffu>(
+        CHECK(bus::write<"", 0xffff'ff00u, 0x0000'00ffu, 0x0000'00ffu>(
                   addr32, 0x41d0'0d00u) |
               async::sync_wait());
 


### PR DESCRIPTION
Problem:

-  `mmio_bus` wasn't updated with `RegName` template parameter. Compilations are failing.

Solution:

- Add proper template parameters for `mmio_bus::read` and `mmio_bus::write`
