### PR TITLE
:arrow_up: Update `.gitignore` for mermaid config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ CMakePresets.json
 mull.yml
 requirements.txt
 docs/puppeteer_config.json
+docs/mermaid.conf
 __pycache__


### PR DESCRIPTION
Problem:
- We receive docs/mermaid.conf from the CICD repo upstream, but it's not in the `.gitignore` file.

Solution:
- Add it to the `.gitignore` file.