### PR TITLE
:bug: Fix `.gitignore` to take account of `.github/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# ignore all directories that start with .
+# ignore all directories that start with . (except .github/)
 **/.*/
+!.github/
 
 # ignore conventionally-named build directories
 **/build*/


### PR DESCRIPTION
Problem:
- The `.gitignore` file accidentally ignores the `.github` directory.

Solution:
- Fix it.