### PR TITLE
:art: Allow writing paths with multiple values attached

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 22
 

--- a/test/value_path.cpp
+++ b/test/value_path.cpp
@@ -10,7 +10,7 @@ TEST_CASE("path with value (operator=)", "[value_path]") {
     constexpr auto v = "reg"_r / "field"_f = 5;
     STATIC_REQUIRE(std::is_same_v<groov::get_path_t<decltype(v)>,
                                   decltype("reg.field"_f)>);
-    STATIC_REQUIRE(v.value == 5);
+    STATIC_REQUIRE(v.value == stdx::tuple{5});
 }
 
 TEST_CASE("const path with value (operator=)", "[value_path]") {
@@ -19,7 +19,7 @@ TEST_CASE("const path with value (operator=)", "[value_path]") {
     constexpr auto v = p = 5;
     STATIC_REQUIRE(std::is_same_v<groov::get_path_t<decltype(v)>,
                                   decltype("reg.field"_f)>);
-    STATIC_REQUIRE(v.value == 5);
+    STATIC_REQUIRE(v.value == stdx::tuple{5});
 }
 
 TEST_CASE("path with value (operator())", "[value_path]") {
@@ -27,7 +27,7 @@ TEST_CASE("path with value (operator())", "[value_path]") {
     constexpr auto v = "reg"_r(5);
     STATIC_REQUIRE(
         std::is_same_v<groov::get_path_t<decltype(v)>, decltype("reg"_f)>);
-    STATIC_REQUIRE(v.value == 5);
+    STATIC_REQUIRE(v.value == stdx::tuple{5});
 }
 
 TEST_CASE("path with value can resolve path", "[value_path]") {
@@ -36,7 +36,7 @@ TEST_CASE("path with value can resolve path", "[value_path]") {
     constexpr auto r = groov::resolve(v, "reg"_r);
     STATIC_REQUIRE(
         std::is_same_v<groov::get_path_t<decltype(r)>, decltype("field"_f)>);
-    STATIC_REQUIRE(r.value == 5);
+    STATIC_REQUIRE(r.value == stdx::tuple{5});
 }
 
 TEST_CASE("mismatched path gives invalid resolution", "[value_path]") {
@@ -70,8 +70,9 @@ TEST_CASE("register with multiple field values", "[value_path]") {
             groov::value_path<
                 groov::path<"reg">,
                 stdx::tuple<
-                    groov::value_path<groov::path<"field1">, int>,
-                    groov::value_path<groov::path<"field2">, double>>> const>);
+                    groov::value_path<groov::path<"field1">, stdx::tuple<int>>,
+                    groov::value_path<groov::path<"field2">,
+                                      stdx::tuple<double>>>> const>);
 }
 
 TEST_CASE("retrieve values by path", "[value_path]") {
@@ -86,7 +87,7 @@ TEST_CASE("drill down into value with partial path", "[value_path]") {
     constexpr auto r = v["reg"_r];
     STATIC_REQUIRE(
         std::is_same_v<groov::get_path_t<decltype(r)>, decltype("field"_f)>);
-    STATIC_REQUIRE(r.value == 5);
+    STATIC_REQUIRE(r.value == stdx::tuple{5});
 }
 
 TEST_CASE("retrieve located value by path", "[value_path]") {
@@ -94,8 +95,8 @@ TEST_CASE("retrieve located value by path", "[value_path]") {
     constexpr auto v = "reg"_r / "field"_f = 5;
     constexpr auto f = v["reg"_r];
     STATIC_REQUIRE(
-        std::is_same_v<decltype(f),
-                       groov::value_path<groov::path<"field">, int> const>);
+        std::is_same_v<decltype(f), groov::value_path<groov::path<"field">,
+                                                      stdx::tuple<int>> const>);
     STATIC_REQUIRE(f["field"_f] == 5);
 }
 
@@ -127,7 +128,7 @@ TEST_CASE("path with value can be extended", "[value_path]") {
     constexpr auto v = "reg"_r / ("field"_f = 5);
     STATIC_REQUIRE(std::is_same_v<groov::get_path_t<decltype(v)>,
                                   decltype("reg.field"_f)>);
-    STATIC_REQUIRE(v.value == 5);
+    STATIC_REQUIRE(v.value == stdx::tuple{5});
     STATIC_REQUIRE(v["reg"_r]["field"_f] == 5);
 }
 

--- a/test/write.cpp
+++ b/test/write.cpp
@@ -103,6 +103,13 @@ TEST_CASE("write a field", "[write]") {
     CHECK(data0 == 0b1'0001'1u);
 }
 
+TEST_CASE("write a field (alt)", "[write]") {
+    using namespace groov::literals;
+    data0 = 0b1'1010'1u;
+    CHECK(sync_write(grp("reg0"_r("field1"_f = 1))));
+    CHECK(data0 == 0b1'0001'1u);
+}
+
 TEST_CASE("set a field", "[write]") {
     using namespace groov::literals;
     data0 = 0u;
@@ -126,12 +133,33 @@ TEST_CASE("write multiple fields to the same register", "[write]") {
     CHECK(data0 == 0b1'0101'1u);
 }
 
+TEST_CASE("write multiple fields to the same register (alt)", "[write]") {
+    using namespace groov::literals;
+    data0 = 0b1'1010'0u;
+    bus::num_writes = 0;
+    CHECK(sync_write(grp("reg0"_r("field0"_f = 1, "field1"_f = 0b101u))));
+    CHECK(bus::num_writes == 1);
+    CHECK(data0 == 0b1'0101'1u);
+}
+
 TEST_CASE("write multiple fields to different registers", "[write]") {
     using namespace groov::literals;
     data0 = 0b1'1010'0u;
     data1 = 0b1'1010'0u;
     bus::num_writes = 0;
     CHECK(sync_write(grp("reg0.field0"_f = 1, "reg1.field1"_f = 0b101u)));
+    CHECK(bus::num_writes == 2);
+    CHECK(data0 == 0b1'1010'1u);
+    CHECK(data1 == 0b1'0101'0u);
+}
+
+TEST_CASE("write multiple fields to different registers (alt)", "[write]") {
+    using namespace groov::literals;
+    data0 = 0b1'1010'0u;
+    data1 = 0b1'1010'0u;
+    bus::num_writes = 0;
+    CHECK(sync_write(
+        grp("reg0"_r("field0"_f = 1), "reg1"_r("field1"_f = 0b101u))));
     CHECK(bus::num_writes == 2);
     CHECK(data0 == 0b1'1010'1u);
     CHECK(data1 == 0b1'0101'0u);
@@ -144,6 +172,19 @@ TEST_CASE("write multiple fields to each of multiple registers", "[write]") {
     bus::num_writes = 0;
     CHECK(sync_write(grp("reg0.field0"_f = 1, "reg0.field1"_f = 0b101u,
                          "reg1.field0"_f = 0, "reg1.field1"_f = 0b1010u)));
+    CHECK(bus::num_writes == 2);
+    CHECK(data0 == 0b1'0101'1u);
+    CHECK(data1 == 0b1'1010'0u);
+}
+
+TEST_CASE("write multiple fields to each of multiple registers (alt)",
+          "[write]") {
+    using namespace groov::literals;
+    data0 = 0b1'0000'0u;
+    data1 = 0b1'0000'1u;
+    bus::num_writes = 0;
+    CHECK(sync_write(grp("reg0"_r("field0"_f = 1, "field1"_f = 0b101u),
+                         "reg1"_r("field0"_f = 0, "field1"_f = 0b1010u))));
     CHECK(bus::num_writes == 2);
     CHECK(data0 == 0b1'0101'1u);
     CHECK(data1 == 0b1'1010'0u);


### PR DESCRIPTION
Problem:
- The following syntax (fully qualified paths) works:
```cpp
write(grp("reg.field0"_f = 0, "reg.field1"_f = 1));
```
- But this syntax (treelike grouping) does not:
```cpp
write(grp("reg"_r("field0"_f = 0, "field1"_f = 1)));
```

Solution:
- Handle "tree-valued" paths in `make_spec` and elsewhere.