### PR TITLE
:white_check_mark: Enable CTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(
               include/groov/write_spec.hpp)
 
 if(PROJECT_IS_TOP_LEVEL)
+    include(CTest)
     add_docs(docs)
     add_subdirectory(test)
     clang_tidy_interface(groov)


### PR DESCRIPTION
Problem:
- `CTest` is not included upstream any more.

Solution:
- `include(CTest)` in the top-level `CMakeLists.txt`.