### PR TITLE
:white_check_mark: Add test: "raw" write of a read-only field

### DIFF
--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -21,6 +21,7 @@ add_fail_tests(
 
 function(add_formatted_error_tests)
     add_fail_tests(write_read_only_field)
+    add_fail_tests(write_reg_partial_read_only)
 endfunction()
 
 if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 20)

--- a/test/fail/write_reg_partial_read_only.cpp
+++ b/test/fail/write_reg_partial_read_only.cpp
@@ -1,0 +1,37 @@
+#include "dummy_bus.hpp"
+
+#include <groov/config.hpp>
+#include <groov/identity.hpp>
+#include <groov/path.hpp>
+#include <groov/value_path.hpp>
+#include <groov/write.hpp>
+#include <groov/write_spec.hpp>
+
+#include <async/concepts.hpp>
+#include <async/just_result_of.hpp>
+
+#include <cstdint>
+
+// EXPECT: Attempting to write to a read-only field: field_ro
+
+namespace {
+struct write_bus : dummy_bus {
+    template <stdx::ct_string, auto Mask, auto IdMask, auto IdValue>
+    static auto write(auto addr, auto value) -> async::sender auto {
+        return async::just_result_of([=] { *addr = (*addr & ~Mask) | value; });
+    }
+};
+
+using F0 = groov::field<"field_ro", std::uint8_t, 0, 0,
+                        groov::read_only<groov::w::ignore>>;
+using F1 = groov::field<"field_rw", std::uint32_t, 31, 1>;
+
+std::uint32_t data{};
+using R = groov::reg<"reg", std::uint32_t, &data, groov::w::replace, F0, F1>;
+using G = groov::group<"group", write_bus, R>;
+} // namespace
+
+auto main() -> int {
+    using namespace groov::literals;
+    [[maybe_unused]] auto x = sync_write(G{}("reg"_r = 0xffff'ffff));
+}


### PR DESCRIPTION
Problem:
- There is no test exercising a "raw" (whole register) write where that register has one or more fields marked read-only.

Solution:
- Add a test that should fail when doing a "raw" write to a register containing a read-only field.