### PR TITLE
:fire: Replace old compiler macros

### DIFF
--- a/include/groov/config.hpp
+++ b/include/groov/config.hpp
@@ -326,7 +326,7 @@ struct clear_t {};
 constexpr auto clear = clear_t{};
 
 template <typename Bus, typename RegType>
-CONSTEVAL auto transform_mask(RegType mask) -> RegType {
+consteval auto transform_mask(RegType mask) -> RegType {
     if constexpr (requires { Bus::transform_mask(RegType{}); }) {
         return Bus::transform_mask(mask);
     } else {

--- a/include/groov/path.hpp
+++ b/include/groov/path.hpp
@@ -74,7 +74,7 @@ constexpr inline auto parent(path<> const &) { return path<>{}; }
 template <typename Path> using parent_t = decltype(parent(Path{}));
 
 template <stdx::ct_string S, stdx::ct_string... Parts>
-CONSTEVAL auto make_path() -> pathlike auto {
+consteval auto make_path() -> pathlike auto {
     constexpr auto p = stdx::split<S, '.'>();
     if constexpr (p.second.empty()) {
         if constexpr (p.first.empty()) {

--- a/include/groov/path.hpp
+++ b/include/groov/path.hpp
@@ -89,36 +89,30 @@ consteval auto make_path() -> pathlike auto {
 
 namespace literals {
 #if __clang__ && __clang_major__ <= 14
-template <class T, T... chars>
-CONSTEVAL_UDL auto operator""_g() -> pathlike auto {
+template <class T, T... chars> consteval auto operator""_g() -> pathlike auto {
     constexpr auto s = stdx::ct_string<sizeof...(chars) + 1U>{{chars..., 0}};
     return make_path<s>();
 }
 
-template <class T, T... chars>
-CONSTEVAL_UDL auto operator""_r() -> pathlike auto {
+template <class T, T... chars> consteval auto operator""_r() -> pathlike auto {
     constexpr auto s = stdx::ct_string<sizeof...(chars) + 1U>{{chars..., 0}};
     return make_path<s>();
 }
 
-template <class T, T... chars>
-CONSTEVAL_UDL auto operator""_f() -> pathlike auto {
+template <class T, T... chars> consteval auto operator""_f() -> pathlike auto {
     constexpr auto s = stdx::ct_string<sizeof...(chars) + 1U>{{chars..., 0}};
     return make_path<s>();
 }
 #else
-template <stdx::ct_string S>
-CONSTEVAL_UDL auto operator""_g() -> pathlike auto {
+template <stdx::ct_string S> consteval auto operator""_g() -> pathlike auto {
     return make_path<S>();
 }
 
-template <stdx::ct_string S>
-CONSTEVAL_UDL auto operator""_r() -> pathlike auto {
+template <stdx::ct_string S> consteval auto operator""_r() -> pathlike auto {
     return make_path<S>();
 }
 
-template <stdx::ct_string S>
-CONSTEVAL_UDL auto operator""_f() -> pathlike auto {
+template <stdx::ct_string S> consteval auto operator""_f() -> pathlike auto {
     return make_path<S>();
 }
 #endif

--- a/include/groov/read.hpp
+++ b/include/groov/read.hpp
@@ -59,7 +59,7 @@ template <typename Group> struct to_register_q {
 
 template <typename Register> using to_fields = typename Register::children_t;
 
-template <typename F, auto Mask> CONSTEVAL auto check_writeonly_field() {
+template <typename F, auto Mask> consteval auto check_writeonly_field() {
     constexpr auto mask_overlap = F::template mask<decltype(Mask)> & Mask;
     if constexpr (registerlike<F>) {
         STATIC_ASSERT(not write_only_write_function<typename F::write_fn_t> or
@@ -75,7 +75,7 @@ template <typename F, auto Mask> CONSTEVAL auto check_writeonly_field() {
 }
 
 template <typename Bus, typename L, typename Masks>
-CONSTEVAL auto check_write_only() -> void {
+consteval auto check_write_only() -> void {
     [[maybe_unused]] auto r = stdx::for_each(
         []<typename... Fs>(boost::mp11::mp_list<Fs...>, auto mask) {
             constexpr auto read_mask = transform_mask<Bus>(mask());

--- a/include/groov/write.hpp
+++ b/include/groov/write.hpp
@@ -56,7 +56,7 @@ template <typename Reg>
 using compute_reg_id_value_t =
     std::integral_constant<typename Reg::type_t, Reg::unused_identity_value>;
 
-template <typename F> CONSTEVAL auto check_readonly_field() {
+template <typename F> consteval auto check_readonly_field() {
     if constexpr (registerlike<F>) {
         STATIC_ASSERT(not read_only_write_function<typename F::write_fn_t>,
                       "Attempting to write to a read-only register: {}",
@@ -67,7 +67,7 @@ template <typename F> CONSTEVAL auto check_readonly_field() {
     }
 }
 
-template <typename Bus, typename L> CONSTEVAL auto check_read_only() -> void {
+template <typename Bus, typename L> consteval auto check_read_only() -> void {
     [[maybe_unused]] auto r = stdx::for_each(
         []<typename... Fs>(boost::mp11::mp_list<Fs...>) {
             (check_readonly_field<Fs>(), ...);
@@ -75,7 +75,7 @@ template <typename Bus, typename L> CONSTEVAL auto check_read_only() -> void {
         L{});
 }
 
-template <typename F, auto Mask> CONSTEVAL auto check_rmw_field() {
+template <typename F, auto Mask> consteval auto check_rmw_field() {
     constexpr auto mask_overlap = F::template mask<decltype(Mask)> & Mask;
     STATIC_ASSERT(not write_only_write_function<typename F::write_fn_t> or
                       identity_write_function<typename F::write_fn_t> or
@@ -84,7 +84,7 @@ template <typename F, auto Mask> CONSTEVAL auto check_rmw_field() {
 }
 
 template <typename Bus, typename L, typename Masks>
-CONSTEVAL auto check_rmw() -> void {
+consteval auto check_rmw() -> void {
     [[maybe_unused]] auto r = stdx::for_each(
         []<typename... Fs>(boost::mp11::mp_list<Fs...>, auto mask) {
             [[maybe_unused]] constexpr auto write_mask =

--- a/include/groov/write_spec.hpp
+++ b/include/groov/write_spec.hpp
@@ -6,7 +6,6 @@
 #include <groov/read_spec.hpp>
 #include <groov/resolve.hpp>
 
-#include <stdx/compiler.hpp>
 #include <stdx/tuple.hpp>
 #include <stdx/tuple_algorithms.hpp>
 #include <stdx/type_traits.hpp>

--- a/test/config.cpp
+++ b/test/config.cpp
@@ -186,7 +186,7 @@ struct be_bus {
     }
 
     template <typename RegType>
-    CONSTEVAL static auto transform_mask(RegType mask) -> RegType {
+    consteval static auto transform_mask(RegType mask) -> RegType {
         using A = std::array<std::uint8_t, sizeof(RegType)>;
         auto arr = stdx::bit_cast<A>(mask);
         for (auto &i : arr) {

--- a/test/read.cpp
+++ b/test/read.cpp
@@ -291,7 +291,7 @@ struct be_bus {
     }
 
     template <typename RegType>
-    CONSTEVAL static auto transform_mask(RegType mask) -> RegType {
+    consteval static auto transform_mask(RegType mask) -> RegType {
         using A = std::array<std::uint8_t, sizeof(RegType)>;
         auto arr = stdx::bit_cast<A>(mask);
         for (auto &i : arr) {

--- a/test/write.cpp
+++ b/test/write.cpp
@@ -512,7 +512,7 @@ struct be_bus {
     }
 
     template <typename RegType>
-    CONSTEVAL static auto transform_mask(RegType mask) -> RegType {
+    consteval static auto transform_mask(RegType mask) -> RegType {
         using A = std::array<std::uint8_t, sizeof(RegType)>;
         auto arr = stdx::bit_cast<A>(mask);
         for (auto &i : arr) {


### PR DESCRIPTION
Problem:
- `consteval` and `constinit` have full support in our supported compilers, but we're still using `CONSTEVAL` and `CONSTINIT`.

Solution:
- Remove uses of `CONSTEVAL` and `CONSTINIT`.