### PR TITLE
:goal_net: Improve errors messages for group path resolution

### DIFF
--- a/include/groov/boost_extra.hpp
+++ b/include/groov/boost_extra.hpp
@@ -49,5 +49,15 @@ struct mp_gather_t<F, List<Ts...>> {
         boost::mp11::mp_push_front<mp_gather_q<F, boost::mp11::mp_second<P>>,
                                    boost::mp11::mp_first<P>>;
 };
+
+template <typename L> struct has_duplicates_q {
+    template <typename T>
+    using fn = boost::mp11::mp_bool<(boost::mp11::mp_count<L, T>::value > 1)>;
+};
 } // namespace detail
+
+template <typename L>
+using mp_duplicates = boost::mp11::mp_copy_if_q<boost::mp11::mp_unique<L>,
+                                                detail::has_duplicates_q<L>>;
+
 } // namespace boost::mpx

--- a/include/groov/config.hpp
+++ b/include/groov/config.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <groov/boost_extra.hpp>
 #include <groov/identity.hpp>
 #include <groov/make_spec.hpp>
 #include <groov/resolve.hpp>
@@ -8,6 +9,7 @@
 
 #include <stdx/bit.hpp>
 #include <stdx/ct_string.hpp>
+#include <stdx/static_assert.hpp>
 #include <stdx/type_traits.hpp>
 #include <stdx/utility.hpp>
 
@@ -224,15 +226,33 @@ template <typename G> struct group_resolves_q {
     template <pathlike P> using fn = is_resolvable_t<G, P>;
 };
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 template <typename G, typename L> constexpr auto check_valid_config() -> void {
-    static_assert(boost::mp11::mp_is_set<L>::value,
-                  "Duplicate path passed to group");
-    static_assert(boost::mp11::mp_all_of_q<L, group_resolves_q<G>>::value,
-                  "Unresolvable path passed to group");
+    using duplicates_t = boost::mpx::mp_duplicates<L>;
+    constexpr auto no_duplicates = boost::mp11::mp_empty<duplicates_t>::value;
+    if constexpr (not no_duplicates) {
+        STATIC_ASSERT(no_duplicates, "Duplicate path ({}) passed to group ({})",
+                      boost::mp11::mp_front<duplicates_t>::to_string(),
+                      G::name);
+    }
+
+    using unresolved_t = boost::mp11::mp_remove_if_q<L, group_resolves_q<G>>;
+    constexpr auto resolved = boost::mp11::mp_empty<unresolved_t>::value;
+    if constexpr (not resolved) {
+        STATIC_ASSERT(resolved, "Unresolvable path ({}) passed to group ({})",
+                      boost::mp11::mp_front<unresolved_t>::to_string(),
+                      G::name);
+    }
+
     stdx::template_for_each<L>([]<typename P>() {
         using rest = boost::mp11::mp_remove<L, P>;
-        static_assert(boost::mp11::mp_none_of_q<rest, resolves_q<P>>::value,
-                      "Redundant path passed to group");
+        using resolvers_t = boost::mp11::mp_copy_if_q<rest, resolves_q<P>>;
+        constexpr auto has_resolver = boost::mp11::mp_empty<resolvers_t>::value;
+        if constexpr (not has_resolver) {
+            STATIC_ASSERT(
+                has_resolver, "Redundant path ({}) passed to group ({})",
+                boost::mp11::mp_front<resolvers_t>::to_string(), G::name);
+        }
     });
 }
 

--- a/include/groov/path.hpp
+++ b/include/groov/path.hpp
@@ -5,6 +5,7 @@
 
 #include <stdx/compiler.hpp>
 #include <stdx/ct_string.hpp>
+#include <stdx/tuple.hpp>
 #include <stdx/type_traits.hpp>
 
 #include <boost/mp11/algorithm.hpp>
@@ -51,6 +52,12 @@ template <stdx::ct_string... Parts> struct path {
     }
 
     constexpr static auto empty = std::bool_constant<sizeof...(Parts) == 0>{};
+
+    consteval static auto to_string() {
+        using namespace stdx::literals;
+        return stdx::tuple{Parts...}.join(
+            ""_cts, [](auto lhs, auto rhs) { return lhs + "."_cts + rhs; });
+    }
 
   private:
     friend constexpr auto operator==(path, path) -> bool = default;

--- a/test/fail/CMakeLists.txt
+++ b/test/fail/CMakeLists.txt
@@ -5,9 +5,6 @@ function(add_fail_tests)
 endfunction()
 
 add_fail_tests(
-    group_duplicate_path
-    group_redundant_path
-    group_unresolvable_path
     path_ambiguous
     path_mismatch
     path_too_long
@@ -21,6 +18,20 @@ add_fail_tests(
 
 target_compile_options(EXPECT_FAIL.sync_write_nontrivial_nodiscard.cpp
                        PRIVATE -Werror)
+
+function(add_formatted_errors_tests)
+    add_fail_tests(group_duplicate_path group_redundant_path
+                   group_unresolvable_path)
+endfunction()
+
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CMAKE_CXX_COMPILER_VERSION}
+                                                 VERSION_GREATER_EQUAL 15)
+    add_formatted_errors_tests()
+endif()
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION}
+                                               VERSION_GREATER_EQUAL 13.2)
+    add_formatted_errors_tests()
+endif()
 
 add_subdirectory(read)
 add_subdirectory(write)

--- a/test/fail/group_duplicate_path.cpp
+++ b/test/fail/group_duplicate_path.cpp
@@ -6,7 +6,7 @@
 
 #include <cstdint>
 
-// EXPECT: Duplicate path passed to group
+// EXPECT: Duplicate path \(reg0\) passed to group
 
 namespace {
 using F0 = groov::field<"field0", std::uint8_t, 0, 0>;

--- a/test/fail/group_redundant_path.cpp
+++ b/test/fail/group_redundant_path.cpp
@@ -6,7 +6,7 @@
 
 #include <cstdint>
 
-// EXPECT: Redundant path passed to group
+// EXPECT: Redundant path \(reg0.field0\) passed to group
 
 namespace {
 using F0 = groov::field<"field0", std::uint8_t, 0, 0>;

--- a/test/fail/group_unresolvable_path.cpp
+++ b/test/fail/group_unresolvable_path.cpp
@@ -6,7 +6,7 @@
 
 #include <cstdint>
 
-// EXPECT: Unresolvable path passed to group
+// EXPECT: Unresolvable path \(reg0.field1\) passed to group
 
 namespace {
 using F0 = groov::field<"field0", std::uint8_t, 0, 0>;


### PR DESCRIPTION
Problem:
- A typo in a construction like `grp / "reg"_r` leads to an error that says, "Unresolvable path passed to group" -- it does not tell you which path could not be resolved.

Solution:
- Report which path was unresolvable.