### PR TITLE
:art: Allow MMIO bus to deal with pointer addresses

### DIFF
--- a/include/groov/mmio_bus.hpp
+++ b/include/groov/mmio_bus.hpp
@@ -7,15 +7,19 @@
 #include <async/just_result_of.hpp>
 #include <async/then.hpp>
 
+#include <stdx/bit.hpp>
+#include <stdx/ct_conversions.hpp>
 #include <stdx/ct_string.hpp>
 
 #include <boost/mp11/algorithm.hpp>
 #include <boost/mp11/integral.hpp>
 #include <boost/mp11/list.hpp>
 
-#include <bit>
 #include <concepts>
+#include <cstddef>
 #include <cstdint>
+#include <limits>
+#include <type_traits>
 
 namespace groov {
 namespace detail {
@@ -81,23 +85,42 @@ template <auto Mask, decltype(Mask) IdMask> struct subword_satisfies {
 } // namespace detail
 
 struct cpp_mem_iface {
-    template <std::unsigned_integral T> static auto store(std::uintptr_t addr) {
+    template <std::unsigned_integral T>
+    static auto store(std::uintptr_t iaddr) {
         return async::then([=](T value) -> void {
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-            *reinterpret_cast<T volatile *>(addr) = value;
+            auto addr = stdx::bit_cast<T volatile *>(iaddr);
+            *addr = value;
         });
     }
 
     template <std::unsigned_integral T>
-    static auto load(std::uintptr_t addr) -> async::sender auto {
+    static auto load(std::uintptr_t iaddr) -> async::sender auto {
         return async::just_result_of([=]() -> T {
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-            return *reinterpret_cast<T volatile *>(addr);
+            auto addr = stdx::bit_cast<T volatile *>(iaddr);
+            return *addr;
         });
     }
 
     template <typename T> constexpr static std::size_t alignment = alignof(T);
 };
+
+namespace detail {
+template <std::unsigned_integral T, std::unsigned_integral U>
+constexpr auto convert_addr(U u) -> T {
+    if constexpr (sizeof(T) > sizeof(U)) {
+        return static_cast<T>(u);
+    } else {
+        static_assert(std::same_as<T, U>);
+        return u;
+    }
+}
+
+template <std::unsigned_integral T, std::unsigned_integral U>
+constexpr auto convert_addr(U *p) -> T {
+    static_assert(sizeof(T) == sizeof(U *));
+    return stdx::bit_cast<T>(p);
+}
+} // namespace detail
 
 template <typename HardwareInterface = cpp_mem_iface> struct mmio_bus {
     using iface = HardwareInterface;
@@ -123,12 +146,14 @@ template <typename HardwareInterface = cpp_mem_iface> struct mmio_bus {
             detail::mp_copy_if_q<subwords_aligned_and_fit,
                                  detail::subword_satisfies<Mask, IdMask>>;
 
+        auto iaddr = detail::convert_addr<std::uintptr_t>(addr);
+
         if constexpr (!detail::mp_empty<subword_candidates>::value) {
             using subword = detail::mp_first<subword_candidates>;
             using subword_t = typename subword::subword_t;
 
             auto const write_val = value | IdValue;
-            auto const subword_addr = addr + subword::offset;
+            auto const subword_addr = iaddr + subword::offset;
             auto const subword_write_val =
                 static_cast<subword_t>(write_val >> (subword::offset * 8));
 
@@ -136,21 +161,22 @@ template <typename HardwareInterface = cpp_mem_iface> struct mmio_bus {
                    iface::template store<subword_t>(subword_addr);
 
         } else {
-            return iface::template load<base_type>(addr) |
+            return iface::template load<base_type>(iaddr) |
                    async::then([=](base_type old) {
                        auto const bits_to_update = value & Mask;
                        auto const bits_to_writeback = old & ~Mask & ~IdMask;
 
                        return bits_to_update | bits_to_writeback | IdValue;
                    }) |
-                   iface::template store<base_type>(addr);
+                   iface::template store<base_type>(iaddr);
         }
     }
 
     template <stdx::ct_string, std::unsigned_integral auto Mask>
     static auto read(auto addr) -> async::sender auto {
         using base_type = decltype(Mask);
-        return iface::template load<base_type>(addr);
+        auto iaddr = detail::convert_addr<std::uintptr_t>(addr);
+        return iface::template load<base_type>(iaddr);
     }
 };
 } // namespace groov

--- a/test/mmio_bus.cpp
+++ b/test/mmio_bus.cpp
@@ -6,14 +6,16 @@
 #include <async/sync_wait.hpp>
 #include <async/then.hpp>
 
+#include <stdx/bit.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstddef>
 #include <cstdint>
 
 namespace {
-uint32_t volatile reg32{};
-auto addr32 = reinterpret_cast<std::uintptr_t>(&reg32);
+uint32_t reg32{};
 } // namespace
 
 using namespace groov::literals;
@@ -22,13 +24,13 @@ struct iface {
     static inline std::size_t num_stores{};
     static inline std::size_t num_loads{};
 
-    template <std::unsigned_integral T> static auto store(std::uintptr_t addr) {
+    template <std::unsigned_integral T> static auto store(auto addr) {
         ++num_stores;
         return groov::cpp_mem_iface::template store<T>(addr);
     }
 
     template <std::unsigned_integral T>
-    static auto load(std::uintptr_t addr) -> async::sender auto {
+    static auto load(auto addr) -> async::sender auto {
         ++num_loads;
         return groov::cpp_mem_iface::template load<T>(addr);
     }
@@ -40,13 +42,16 @@ struct iface {
 
 using bus = groov::mmio_bus<iface>;
 
-TEST_CASE("subword write optimization", "[mmio_bus]") {
+TEMPLATE_TEST_CASE("subword write optimization", "[mmio_bus]", std::uintptr_t,
+                   decltype(&reg32)) {
+    auto addr = stdx::bit_cast<TestType>(&reg32);
+
     reg32 = 0x8765'4321u;
     iface::num_stores = {};
     iface::num_loads = {};
 
     SECTION("write the whole register") {
-        CHECK(bus::write<"", 0xffff'ffffu, 0u, 0u>(addr32, 0xc001'd00du) |
+        CHECK(bus::write<"", 0xffff'ffffu, 0u, 0u>(addr, 0xc001'd00du) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -55,8 +60,7 @@ TEST_CASE("subword write optimization", "[mmio_bus]") {
     }
 
     SECTION("write byte 0") {
-        CHECK(bus::write<"", 0xffu, 0u, 0u>(addr32, 0x38u) |
-              async::sync_wait());
+        CHECK(bus::write<"", 0xffu, 0u, 0u>(addr, 0x38u) | async::sync_wait());
 
         CHECK(iface::num_stores == 1);
         CHECK(iface::num_loads == 0);
@@ -64,7 +68,7 @@ TEST_CASE("subword write optimization", "[mmio_bus]") {
     }
 
     SECTION("write byte 1") {
-        CHECK(bus::write<"", 0xff00u, 0u, 0u>(addr32, 0x4200u) |
+        CHECK(bus::write<"", 0xff00u, 0u, 0u>(addr, 0x4200u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -73,7 +77,7 @@ TEST_CASE("subword write optimization", "[mmio_bus]") {
     }
 
     SECTION("write byte 2") {
-        CHECK(bus::write<"", 0xff'0000u, 0u, 0u>(addr32, 0x55'0000u) |
+        CHECK(bus::write<"", 0xff'0000u, 0u, 0u>(addr, 0x55'0000u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -82,7 +86,7 @@ TEST_CASE("subword write optimization", "[mmio_bus]") {
     }
 
     SECTION("write byte 3") {
-        CHECK(bus::write<"", 0xff00'0000u, 0u, 0u>(addr32, 0x1300'0000u) |
+        CHECK(bus::write<"", 0xff00'0000u, 0u, 0u>(addr, 0x1300'0000u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -91,7 +95,7 @@ TEST_CASE("subword write optimization", "[mmio_bus]") {
     }
 
     SECTION("write word at offset 0") {
-        CHECK(bus::write<"", 0xffffu, 0u, 0u>(addr32, 0xd00du) |
+        CHECK(bus::write<"", 0xffffu, 0u, 0u>(addr, 0xd00du) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -100,7 +104,7 @@ TEST_CASE("subword write optimization", "[mmio_bus]") {
     }
 
     SECTION("write word at offset 2") {
-        CHECK(bus::write<"", 0xffff'0000u, 0u, 0u>(addr32, 0x6502'0000u) |
+        CHECK(bus::write<"", 0xffff'0000u, 0u, 0u>(addr, 0x6502'0000u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -109,13 +113,16 @@ TEST_CASE("subword write optimization", "[mmio_bus]") {
     }
 }
 
-TEST_CASE("read-modify-write", "[mmio_bus]") {
+TEMPLATE_TEST_CASE("read-modify-write", "[mmio_bus]", std::uintptr_t,
+                   decltype(&reg32)) {
+    auto addr = stdx::bit_cast<TestType>(&reg32);
+
     reg32 = 0xffff'ffffu;
     iface::num_stores = {};
     iface::num_loads = {};
 
     SECTION("write a single bit") {
-        CHECK(bus::write<"", 0x1u, 0u, 0u>(addr32, 0u) | async::sync_wait());
+        CHECK(bus::write<"", 0x1u, 0u, 0u>(addr, 0u) | async::sync_wait());
 
         CHECK(iface::num_stores == 1);
         CHECK(iface::num_loads == 1);
@@ -123,7 +130,7 @@ TEST_CASE("read-modify-write", "[mmio_bus]") {
     }
 
     SECTION("write a nibble") {
-        CHECK(bus::write<"", 0xf000u, 0u, 0u>(addr32, 0x7000u) |
+        CHECK(bus::write<"", 0xf000u, 0u, 0u>(addr, 0x7000u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -132,13 +139,16 @@ TEST_CASE("read-modify-write", "[mmio_bus]") {
     }
 }
 
-TEST_CASE("idmask write optimization", "[mmio_bus]") {
+TEMPLATE_TEST_CASE("idmask write optimization", "[mmio_bus]", std::uintptr_t,
+                   decltype(&reg32)) {
+    auto addr = stdx::bit_cast<TestType>(&reg32);
+
     reg32 = 0xffff'ffffu;
     iface::num_stores = {};
     iface::num_loads = {};
 
     SECTION("write bit in byte 0") {
-        CHECK(bus::write<"", 0x1u, 0xffff'fffeu, 0xffff'fffeu>(addr32, 0u) |
+        CHECK(bus::write<"", 0x1u, 0xffff'fffeu, 0xffff'fffeu>(addr, 0u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -146,7 +156,7 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
         CHECK(reg32 == 0xffff'fffeu);
     }
     SECTION("write bit in byte 0 - requires subword write") {
-        CHECK(bus::write<"", 0x1u, 0xfeu, 0xfeu>(addr32, 0u) |
+        CHECK(bus::write<"", 0x1u, 0xfeu, 0xfeu>(addr, 0u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -155,9 +165,9 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
     }
 
     SECTION("write nibble in byte 1") {
-        CHECK(bus::write<"", 0x0f00u, 0xffff'f0ffu, 0xffff'f0ffu>(addr32,
-                                                                  0x0300u) |
-              async::sync_wait());
+        CHECK(
+            bus::write<"", 0x0f00u, 0xffff'f0ffu, 0xffff'f0ffu>(addr, 0x0300u) |
+            async::sync_wait());
 
         CHECK(iface::num_stores == 1);
         CHECK(iface::num_loads == 0);
@@ -165,7 +175,7 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
     }
 
     SECTION("write nibble in byte 1 - requires subword write") {
-        CHECK(bus::write<"", 0x0f00u, 0xf0ffu, 0xf0ffu>(addr32, 0x0300u) |
+        CHECK(bus::write<"", 0x0f00u, 0xf0ffu, 0xf0ffu>(addr, 0x0300u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -174,7 +184,7 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
     }
 
     SECTION("write across two bytes - requires subword write") {
-        CHECK(bus::write<"", 0x0ff0u, 0xf00fu, 0xf00fu>(addr32, 0x0340u) |
+        CHECK(bus::write<"", 0x0ff0u, 0xf00fu, 0xf00fu>(addr, 0x0340u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -184,7 +194,7 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
 
     SECTION("write nibble in byte 2") {
         CHECK(bus::write<"", 0xf0'0000u, 0xff0f'ffffu, 0xff0f'ffffu>(
-                  addr32, 0x40'0000u) |
+                  addr, 0x40'0000u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -194,7 +204,7 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
 
     SECTION("write nibble in byte 3") {
         CHECK(bus::write<"", 0x0f00'0000u, 0xf0ff'ffffu, 0xf0ff'ffffu>(
-                  addr32, 0x1300'0000u) |
+                  addr, 0x1300'0000u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -204,7 +214,7 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
 
     SECTION("write across three bytes") {
         CHECK(bus::write<"", 0xff'ffffu, 0xff00'0000u, 0xff00'0000u>(
-                  addr32, 0x41'd00du) |
+                  addr, 0x41'd00du) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);
@@ -213,9 +223,8 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
     }
 
     SECTION("write across three bytes - check id bit write") {
-        CHECK(
-            bus::write<"", 0x00ff'ffffu, 0xff00'0000u, 0u>(addr32, 0x41'd00du) |
-            async::sync_wait());
+        CHECK(bus::write<"", 0x00ff'ffffu, 0xff00'0000u, 0u>(addr, 0x41'd00du) |
+              async::sync_wait());
 
         CHECK(iface::num_stores == 1);
         CHECK(iface::num_loads == 0);
@@ -224,7 +233,7 @@ TEST_CASE("idmask write optimization", "[mmio_bus]") {
 
     SECTION("write across three bytes - start at byte 1") {
         CHECK(bus::write<"", 0xffff'ff00u, 0x0000'00ffu, 0x0000'00ffu>(
-                  addr32, 0x41d0'0d00u) |
+                  addr, 0x41d0'0d00u) |
               async::sync_wait());
 
         CHECK(iface::num_stores == 1);


### PR DESCRIPTION
Problem:
- The MMIO bus implementation assumes that the addresses of registers are integral types, but it is possible (and common in tests) for addresses to be actual pointers to register data.

Solution:
- Do the correct conversion to `std::uintptr_t` for either integral types or pointer types.